### PR TITLE
Ctrl+C improvements, fixes #17

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ And then:
 ```
 rush -- a cross-platform command-line tool for executing jobs in parallel
 
-Version: 0.1.9
+Version: 0.2.0
 
 Author: Wei Shen <shenwei356@gmail.com>
 
@@ -183,6 +183,7 @@ Examples:
       b
       c
   11. assign value to variable, like "awk -v"
+      # seq 1 | rush 'echo Hello, {fname} {lname}!' -v fname=Wei,lname=Shen
       $ seq 1 | rush 'echo Hello, {fname} {lname}!' -v fname=Wei -v lname=Shen
       Hello, Wei Shen!
   12. preset variable (Macro)
@@ -194,15 +195,21 @@ Examples:
       [INFO] ignore cmd #1: sleep 1; echo 1
       [ERRO] run cmd #1: sleep 2; echo 2: time out
       [ERRO] run cmd #2: sleep 3; echo 3: time out
+  14. escape special symbols
+      $ seq 1 | rush 'echo -e "a\tb" | awk "{print $1}"' -q
+      a
 
   More examples: https://github.com/shenwei356/rush
 
 Flags:
-  -v, --assign stringSlice        assign the value val to the variable var (format: var=val, val also supports replacement strings)
+  -v, --assign strings            assign the value val to the variable var (format: var=val, val also supports replacement strings)
   -c, --continue                  continue jobs. NOTES: 1) successful commands are saved in file (given by flag -C/--succ-cmd-file); 2) if the file does not exist, rush saves data so we can continue jobs next time; 3) if the file exists, rush ignores jobs in it and update the file
       --dry-run                   print command but not run
+  -q, --escape                    escape special symbols like $ which you can customize by flag -Q/--escape-symbols
+  -Q, --escape-symbols string     symbols to escape (default "$#&`")
   -d, --field-delimiter string    field delimiter in records, support regular expression (default "\\s+")
-  -i, --infile stringSlice        input data file, multi-values supported
+  -h, --help                      help for rush
+  -i, --infile strings            input data file, multi-values supported
   -j, --jobs int                  run n jobs in parallel (default value depends on your device) (default 4)
   -k, --keep-order                keep output in order of input
   -n, --nrecords int              number of records sent to a command (default 1)
@@ -365,7 +372,7 @@ Flags:
         # macro + regular expression
         $ echo read_1.fq.gz | rush -v p='{@(.+?)_\d}' 'echo {p} {p}_2.fq.gz'
 
-1. escape special symbols
+1. Escape special symbols
 
         $ seq 1 | rush 'echo "I have $100"'
         I have 00

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Examples:
 
 Flags:
   -v, --assign strings            assign the value val to the variable var (format: var=val, val also supports replacement strings)
+      --cleanup-time              time to allow child processes to clean up between stop / kill signals (unit: seconds, 0 for no time) (default 3)
   -c, --continue                  continue jobs. NOTES: 1) successful commands are saved in file (given by flag -C/--succ-cmd-file); 2) if the file does not exist, rush saves data so we can continue jobs next time; 3) if the file exists, rush ignores jobs in it and update the file
       --dry-run                   print command but not run
   -q, --escape                    escape special symbols like $ which you can customize by flag -Q/--escape-symbols
@@ -213,7 +214,8 @@ Flags:
   -i, --infile strings            input data file, multi-values supported
   -j, --jobs int                  run n jobs in parallel (default value depends on your device) (default 4)
   -k, --keep-order                keep output in order of input
-      --kill-on-ctrl-c            kill child processes on ctrl-c (default true)
+      --no-stop-exes              exe names to exclude from stop signal, example: mspdbsrv.exe; or use all for all exes (default none)
+      --no-kill-exes              exe names to exclude from kill signal, example: mspdbsrv.exe; or use all for all exes (default none)
   -n, --nrecords int              number of records sent to a command (default 1)
   -o, --out-file string           out file ("-" for stdout) (default "-")
       --print-retry-output        print output from retry commands (default true)

--- a/process/process.go
+++ b/process/process.go
@@ -30,7 +30,8 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
-	"sort"
+    "sort"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -39,6 +40,7 @@ import (
 	"github.com/cznic/sortutil"
 	"github.com/pkg/errors"
 	"github.com/shenwei356/go-logging"
+	psutil "github.com/shirou/gopsutil/process"
 )
 
 // Log is *logging.Logger
@@ -74,6 +76,7 @@ type Command struct {
 	Duration time.Duration // runtime
 
 	dryrun bool
+	exitStatus int
 }
 
 // NewCommand create a Command
@@ -104,20 +107,22 @@ var TmpOutputDataBuffer = 1048576 // 1M
 var OutputChunkSize = 16384 // 16K
 
 // Run runs a command and send output to command.Ch in background.
-func (c *Command) Run() error {
-	c.Ch = make(chan string, 1)
+func (c *Command) Run(opts *Options) (chan string, error) {
+	// create a return chan here; we will set the c.Ch in the parent
+	ch := make(chan string, 1)
 
 	if c.dryrun {
-		c.Ch <- c.Cmd + "\n"
-		close(c.Ch)
+		ch <- c.Cmd + "\n"
+		close(ch)
 		c.finishSendOutput = true
-		return nil
+		return ch, nil
 	}
 
-	c.Err = c.run()
-	if c.Err != nil {
-		return c.Err
-	}
+	c.Err = c.run(opts)
+
+	// don't return here, keep going so we can display
+	// the output from commands that error
+	var readErr error = nil
 
 	if Verbose {
 		Log.Infof("finish cmd #%d in %s: %s", c.ID, c.Duration, c.Cmd)
@@ -136,21 +141,21 @@ func (c *Command) Run() error {
 		var existedN int
 		// var N uint64
 		for {
-			n, c.Err = c.reader.Read(buf)
+			n, readErr = c.reader.Read(buf)
 
 			existedN = b.Len()
 			b.Write(buf[0:n])
 
-			if c.Err != nil {
-				if c.Err == io.EOF {
+			if readErr != nil {
+				if readErr == io.EOF {
 					if b.Len() > 0 {
 						// if Verbose {
 						// 	N += uint64(b.Len())
 						// }
-						c.Ch <- b.String() // string(buf[0:n])
+						ch <- b.String() // string(buf[0:n])
 					}
 					b.Reset()
-					c.Err = nil
+					readErr = nil
 				}
 				break
 			}
@@ -164,7 +169,7 @@ func (c *Command) Run() error {
 			// if Verbose {
 			// 	N += uint64(len(bb[0 : i+1]))
 			// }
-			c.Ch <- string(bb[0 : i+1]) // string(buf[0:n])
+			ch <- string(bb[0 : i+1]) // string(buf[0:n])
 
 			b.Reset()
 			if i-existedN+1 < n {
@@ -184,10 +189,18 @@ func (c *Command) Run() error {
 		// 	Log.Infof("finish reading data from: %s", c.Cmd)
 		// }
 
-		close(c.Ch)
+		close(ch)
 		c.finishSendOutput = true
 	}()
-	return nil
+	if c.Err != nil {
+		return ch, c.Err
+	} else {
+		if readErr != nil {
+			return ch, readErr
+		} else {
+			return ch, nil
+		}
+	}
 }
 
 var isWindows bool = runtime.GOOS == "windows"
@@ -230,29 +243,76 @@ func (c *Command) Cleanup() error {
 	return err
 }
 
-// ExitCode returns the exit code associated with a given error
-func (c *Command) ExitCode() int {
-	if c.Err == nil {
-		return 0
-	}
-	if ex, ok := c.Err.(*exec.ExitError); ok {
-		if st, ok := ex.Sys().(syscall.WaitStatus); ok {
-			return st.ExitStatus()
-		}
-	}
-	return 1
-}
-
 // ErrTimeout means command timeout
 var ErrTimeout = fmt.Errorf("time out")
 
 // ErrCancelled means command being cancelled
 var ErrCancelled = fmt.Errorf("cancelled")
 
+func (c *Command) getExitStatus(err error) int {
+	if exitError, ok := err.(*exec.ExitError); ok {
+		waitStatus := exitError.Sys().(syscall.WaitStatus)
+		return waitStatus.ExitStatus()
+	}
+	// no error, so return exitStatus 0
+	return 0
+}
+
+// On Windows, call shell with /s to allow correct interpretation of quotes
+// from https://github.com/junegunn/fzf/blob/390b49653b441c958b82a0f78d9923aef4c1d9a2/src/util/util_windows.go
+func (c *Command) setWindowsCommandAttr(command *exec.Cmd, qcmd string) {
+	command.SysProcAttr = &syscall.SysProcAttr{
+		HideWindow:    false,
+		CmdLine:       fmt.Sprintf(` /s /c "%s"`, qcmd),
+		CreationFlags: 0,
+	}
+}
+
+func isProcessRunning(pid int) bool {
+	_, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return true
+}
+
+// ensure Windows processes go away
+func killWindowsProcessTreeRecursive(childProcess *psutil.Process) {
+	grandChildren, err := childProcess.Children()
+	if grandChildren != nil && err == nil {
+		for _, value := range grandChildren {
+			killWindowsProcessTreeRecursive(value)
+		}
+	}
+	attempts := 1
+	for {
+		if Verbose {
+			Log.Infof("taskkill /t /f /pid %s", strconv.Itoa(int(childProcess.Pid)))
+		}
+		out, err := exec.Command("taskkill", "/t", "/f", "/pid", strconv.Itoa(int(childProcess.Pid))).Output()
+		if Verbose {
+			if err != nil {
+				Log.Error(err)
+			}
+			Log.Infof("%s", out)
+		}
+		
+		if !isProcessRunning(int(childProcess.Pid)) {
+			break
+		} else {
+			time.Sleep(10 * time.Millisecond)
+			attempts += 1
+			if attempts > 30 {
+				break
+			}
+		}
+	}
+}
+
 // run a command and pass output to c.reader.
 // Note that output returns only after finishing run.
 // This function is mainly borrowed from https://github.com/brentp/gargs .
-func (c *Command) run() error {
+func (c *Command) run(opts *Options) error {
 	t := time.Now()
 	chCancelMonitor := make(chan struct{})
 	defer func() {
@@ -269,18 +329,20 @@ func (c *Command) run() error {
 	if c.Timeout > 0 {
 		c.ctx, c.ctxCancel = context.WithTimeout(context.Background(), c.Timeout)
 		if isWindows {
-			command = exec.CommandContext(c.ctx, getShell(), "/c", qcmd)
+			command = exec.CommandContext(c.ctx, getShell())
+			c.setWindowsCommandAttr(command, qcmd)
 		} else {
 			command = exec.CommandContext(c.ctx, getShell(), "-c", qcmd)
 		}
 	} else {
 		if isWindows {
-			command = exec.Command(getShell(), "/c", qcmd)
+			command = exec.Command(getShell())
+			c.setWindowsCommandAttr(command, qcmd)
 		} else {
 			command = exec.Command(getShell(), "-c", qcmd)
 		}
 	}
-
+    
 	pipeStdout, err := command.StdoutPipe()
 	if err != nil {
 		return errors.Wrapf(err, "get stdout pipe of cmd #%d: %s", c.ID, c.Cmd)
@@ -306,7 +368,17 @@ func (c *Command) run() error {
 				Log.Warningf("cancel cmd #%d: %s", c.ID, c.Cmd)
 			}
 			chErr <- ErrCancelled
-			command.Process.Kill()
+			if opts.KillOnCtrlC {
+				if isWindows {
+					childProcess, err := psutil.NewProcess(int32(command.Process.Pid))
+					if err != nil {
+						Log.Error(err)
+					}
+					killWindowsProcessTreeRecursive(childProcess)
+				} else {
+					command.Process.Kill()
+				}
+			}
 		case <-chCancelMonitor:
 			// default:  // must not use default, if you must use, use for loop
 		}
@@ -359,10 +431,14 @@ func (c *Command) run() error {
 			err = command.Wait()
 		}
 
+		if opts.PropExitStatus {
+			c.exitStatus = c.getExitStatus(err)
+		}
+		// get reader even on error, so we can still print the stdout and stderr of the failed child process
+		c.reader = bufio.NewReader(bytes.NewReader(readed))
 		if err != nil {
 			return errors.Wrapf(err, "wait cmd #%d: %s", c.ID, c.Cmd)
 		}
-		c.reader = bufio.NewReader(bytes.NewReader(readed))
 		return nil
 	}
 
@@ -406,6 +482,9 @@ func (c *Command) run() error {
 			err = command.Wait()
 		}
 	}
+	if opts.PropExitStatus {
+		c.exitStatus = c.getExitStatus(err)
+	}
 	if err != nil {
 		return errors.Wrapf(err, "wait cmd #%d: %s", c.ID, c.Cmd)
 	}
@@ -420,8 +499,11 @@ type Options struct {
 	KeepOrder           bool          // keep output order
 	Retries             int           // max retry chances
 	RetryInterval       time.Duration // retry interval
+	PrintRetryOutput    bool          // print output from retries
 	Timeout             time.Duration // timeout
 	StopOnErr           bool          // stop on any error
+	PropExitStatus      bool          // propagate child exit status
+	KillOnCtrlC         bool          // kill child processes on ctrl-c
 	RecordSuccessfulCmd bool          // send successful command to channel
 	Verbose             bool
 }
@@ -429,14 +511,14 @@ type Options struct {
 // Run4Output runs commands in parallel from channel chCmdStr,
 // and returns an output text channel,
 // and a done channel to ensure safe exit.
-func Run4Output(opts *Options, cancel chan struct{}, chCmdStr chan string) (chan string, chan string, chan int) {
+func Run4Output(opts *Options, cancel chan struct{}, chCmdStr chan string) (chan string, chan string, chan int, chan int) {
 	if opts.Verbose {
 		Verbose = true
 	}
-	chCmd, chSuccessfulCmd, doneChCmd := Run(opts, cancel, chCmdStr)
+	chCmd, chSuccessfulCmd, doneChCmd, chExitStatus := Run(opts, cancel, chCmdStr)
 	chOut := make(chan string, opts.Jobs)
 	done := make(chan int)
-
+    
 	go func() {
 		var wg sync.WaitGroup
 
@@ -543,7 +625,7 @@ func Run4Output(opts *Options, cancel chan struct{}, chCmdStr chan string) (chan
 
 			wg.Done()
 		}
-
+        
 		<-doneChCmd
 		wg.Wait()
 		close(chOut)
@@ -553,13 +635,34 @@ func Run4Output(opts *Options, cancel chan struct{}, chCmdStr chan string) (chan
 		// }
 		done <- 1
 	}()
-	return chOut, chSuccessfulCmd, done
+	return chOut, chSuccessfulCmd, done, chExitStatus
+}
+
+// write strings and report done
+func combineWorker(input <-chan string, output chan<- string, wg *sync.WaitGroup) {
+    defer wg.Done()
+	for val := range input {
+		output <- val
+	}
+}
+
+// combine strings in input order
+func combine(inputs []<-chan string, output chan<- string) {
+	group := new(sync.WaitGroup)
+	go func() {
+		for _, input := range inputs {
+			group.Add(1)
+			go combineWorker(input, output, group)
+			group.Wait()  // preserve input order
+		}
+		close(output)
+	}()
 }
 
 // Run runs commands in parallel from channel chCmdStr，
 // and returns a Command channel,
 // and a done channel to ensure safe exit.
-func Run(opts *Options, cancel chan struct{}, chCmdStr chan string) (chan *Command, chan string, chan int) {
+func Run(opts *Options, cancel chan struct{}, chCmdStr chan string) (chan *Command, chan string, chan int, chan int) {
 	if opts.Verbose {
 		Verbose = true
 	}
@@ -570,6 +673,10 @@ func Run(opts *Options, cancel chan struct{}, chCmdStr chan string) (chan *Comma
 		chSuccessfulCmd = make(chan string, opts.Jobs)
 	}
 	done := make(chan int)
+	var chExitStatus chan int
+	if opts.PropExitStatus {
+		chExitStatus = make(chan int)
+	}
 
 	go func() {
 		var wg sync.WaitGroup
@@ -607,11 +714,20 @@ func Run(opts *Options, cancel chan struct{}, chCmdStr chan string) (chan *Comma
 				}
 
 				chances := opts.Retries
+				var outputsToPrint []<-chan string
 				for {
-					err := command.Run()
+					ch, err := command.Run(opts)
 					if err != nil { // fail to run
-						if chances == 0 || opts.StopOnErr {
+                        if chances == 0 || opts.StopOnErr {
+							// print final output
+							outputsToPrint = append(outputsToPrint, ch)
 							Log.Error(err)
+							if opts.PropExitStatus {
+								chExitStatus <- command.exitStatus
+							}
+							command.Ch = make(chan string, 1)
+							combine(outputsToPrint, command.Ch)
+							chCmd <- command
 						} else {
 							Log.Warning(err)
 						}
@@ -626,6 +742,9 @@ func Run(opts *Options, cancel chan struct{}, chCmdStr chan string) (chan *Comma
 								if opts.RecordSuccessfulCmd {
 									close(chSuccessfulCmd)
 								}
+								if opts.PropExitStatus {
+									close(chExitStatus)
+								}
 								done <- 1
 							}
 
@@ -633,6 +752,9 @@ func Run(opts *Options, cancel chan struct{}, chCmdStr chan string) (chan *Comma
 							return
 						}
 						if chances > 0 {
+							if opts.PrintRetryOutput {
+								outputsToPrint = append(outputsToPrint, ch)
+							}
 							if Verbose && opts.Retries > 0 {
 								Log.Warningf("retry %d/%d times: %s",
 									opts.Retries-chances+1,
@@ -644,9 +766,16 @@ func Run(opts *Options, cancel chan struct{}, chCmdStr chan string) (chan *Comma
 						}
 						return
 					}
+					// print final output
+					outputsToPrint = append(outputsToPrint, ch)
+					if opts.PropExitStatus {
+						chExitStatus <- command.exitStatus
+					}
 					break
 				}
 
+				command.Ch = make(chan string, 1)
+				combine(outputsToPrint, command.Ch)
 				chCmd <- command
 				if opts.RecordSuccessfulCmd {
 					chSuccessfulCmd <- cmdStr
@@ -663,7 +792,10 @@ func Run(opts *Options, cancel chan struct{}, chCmdStr chan string) (chan *Comma
 			}
 		}
 
+		if opts.PropExitStatus {
+			close(chExitStatus)
+		}
 		done <- 1
 	}()
-	return chCmd, chSuccessfulCmd, done
+	return chCmd, chSuccessfulCmd, done, chExitStatus
 }

--- a/process/process.go
+++ b/process/process.go
@@ -395,7 +395,8 @@ func (lw *ImmediateLineWriter) WritePrefixedLines(input string, outfh *os.File) 
 		// only include prefixes if jobs are running in parallel
 		if lw.numJobs > 1 {
 			var output string
-			reg := regexp.MustCompile("[\r\n]")
+			// split by \r\n or \n
+			reg := regexp.MustCompile("(?:\r\n|\n)")
 			matchExtents := reg.FindAllStringIndex(input, -1)
 			if len(matchExtents) > 0 {
 				// use runes below, so we work correctly with unicode strings

--- a/process/process.go
+++ b/process/process.go
@@ -258,18 +258,6 @@ func (c *Command) getExitStatus(err error) int {
 	return 0
 }
 
-// On Windows, call shell with /s to allow correct interpretation of quotes
-// from https://github.com/junegunn/fzf/blob/390b49653b441c958b82a0f78d9923aef4c1d9a2/src/util/util_windows.go
-func (c *Command) setWindowsCommandAttr(command *exec.Cmd, qcmd string) {
-	if isWindows {
-		command.SysProcAttr = &syscall.SysProcAttr{
-			HideWindow:    false,
-			CmdLine:       fmt.Sprintf(` /s /c "%s"`, qcmd),
-			CreationFlags: 0,
-		}
-	}
-}
-
 func isProcessRunning(pid int) bool {
 	_, err := os.FindProcess(pid)
 	if err != nil {

--- a/process/process.go
+++ b/process/process.go
@@ -1258,7 +1258,7 @@ func Run(opts *Options, cancel chan struct{}, chCmdStr chan string) (chan *Comma
 										Log.Error("stop on first error")
 									}
 									err = stopChildProcesses(opts.NoStopExes, opts.NoKillExes, opts.CleanupTime)
-                                    if err != nil {
+									if err != nil {
 										if Verbose {
 											Log.Error(err)
 										}

--- a/process/process.go
+++ b/process/process.go
@@ -30,8 +30,8 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
-	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -40,10 +40,14 @@ import (
 	"github.com/cznic/sortutil"
 	"github.com/pkg/errors"
 	"github.com/shenwei356/go-logging"
+	psutil "github.com/shirou/gopsutil/process"
 )
 
 // Log is *logging.Logger
 var Log *logging.Logger
+
+// pid_numSecondsSinceEpoch
+var ChildMarker string = strconv.Itoa(os.Getpid()) + "_" + strconv.FormatInt(time.Now().Unix(), 16)
 
 func init() {
 	if Log == nil {
@@ -124,7 +128,12 @@ func (c *Command) Run(opts *Options, tryNumber int) (chan string, error) {
 	var readErr error = nil
 
 	if Verbose {
-		Log.Infof("finish cmd #%d in %s: %s", c.ID, c.Duration, c.Cmd)
+		if c.exitStatus == 0 {
+			Log.Infof("finish cmd #%d in %s: %s: exit status %d", c.ID, c.Duration, c.Cmd, c.exitStatus)
+		} else {
+			// exitStatus will appear in wait cmd message
+			Log.Infof("finish cmd #%d in %s: %s", c.ID, c.Duration, c.Cmd)
+		}
 	}
 
 	go func() {
@@ -210,24 +219,6 @@ func (c *Command) Run(opts *Options, tryNumber int) (chan string, error) {
 			return ch, nil
 		}
 	}
-}
-
-var isWindows bool = runtime.GOOS == "windows"
-
-func getShell() string {
-	var shell string
-	if isWindows {
-		shell = os.Getenv("COMSPEC")
-		if shell == "" {
-			shell = "C:\\WINDOWS\\System32\\cmd.exe"
-		}
-	} else {
-		shell = os.Getenv("SHELL")
-		if shell == "" {
-			shell = "sh"
-		}
-	}
-	return shell
 }
 
 // Cleanup removes tmpfile
@@ -427,6 +418,377 @@ func (iw ImmediateWriter) Write(p []byte) (n int, err error) {
 	return dataLen, nil
 }
 
+// from https://softwareengineering.stackexchange.com/questions/177428/sets-data-structure-in-golang
+type IntSet struct {
+	set map[int]bool
+}
+
+func (set *IntSet) Add(i int) bool {
+	_, found := set.set[i]
+	set.set[i] = true
+	return !found //False if it existed already
+}
+
+const (
+	INVALID_HANDLE int = 0
+
+	CTRL_C_SIGNAL     int = 0
+	CTRL_BREAK_SIGNAL int = 1
+	KILL_SIGNAL       int = 2
+
+	// bit mask
+	SEND_NO_SIGNAL         int = 0
+	SEND_CTRL_C_SIGNAL     int = 1
+	SEND_CTRL_BREAK_SIGNAL int = 2
+	SEND_KILL_SIGNAL       int = 4
+)
+
+func canSendSignal(childProcessName string, noSignalExes []string) (canSendSignal bool, err error) {
+	canSendSignal = true // first assume true
+	err = nil            // first assume no error
+	if len(noSignalExes) > 0 {
+		for _, noSignalExe := range noSignalExes {
+			if noSignalExe == "all" {
+				canSendSignal = false
+				break
+			} else {
+				if childProcessName == noSignalExe {
+					canSendSignal = false
+					break
+				}
+			}
+		}
+	}
+	return canSendSignal, err
+}
+
+func checkChildProcess(childProcess *psutil.Process, noStopExes []string, noKillExes []string) (processHandle int, considerChild bool, signalsToSend int, err error) {
+	considerChild = false          // first assume false
+	signalsToSend = SEND_NO_SIGNAL // first assume no signal
+	// use err2 for getProcess, since child may no longer exist
+	processHandle, processExists, accessGranted, err2 := getProcess(int(childProcess.Pid))
+	if err2 == nil {
+		if processHandle != INVALID_HANDLE {
+			considerChild, err = doesChildHaveMarker(processHandle)
+			if err == nil {
+				if considerChild {
+					var childProcessName string = ""
+					if len(noStopExes) > 0 || len(noKillExes) > 0 {
+						childProcessName, err = childProcess.Name()
+						if err == nil {
+							if len(childProcessName) == 0 {
+								err = errors.New("childProcessName is empty")
+							}
+						}
+						if err != nil {
+							if Verbose {
+								Log.Error(err)
+							}
+						}
+					}
+					signalsToSend, err = getSignalsToSend(childProcessName, noStopExes, noKillExes)
+				}
+			} else {
+				if Verbose {
+					Log.Error(err)
+				}
+			}
+		} else {
+			// failed to open child process, so don't consider it
+		}
+	} else {
+		// failed to open child process, so don't consider it
+		// check response
+		if processExists {
+			if accessGranted {
+				// report errors from processes we could access
+				if Verbose {
+					Log.Error(err2)
+				}
+			} else { // access denied
+				// ignore error, since we failed to get a handle to the child
+				// it could be a system process that we are skipping anyway
+			}
+		} else { // process no longer exists
+			// ignore error since no process to signal
+		}
+	}
+	return processHandle, considerChild, signalsToSend, err
+}
+
+type ProcessRecord struct {
+	processHandle int
+	pid           int
+	signalsToSend int
+}
+
+// get process tree in bottom up order
+func getProcessTreeRecursive(
+	childProcess *psutil.Process,
+	noStopExes []string,
+	noKillExes []string,
+	pidsVisited *IntSet,
+) (processRecords []ProcessRecord) {
+	if considerPid(int(childProcess.Pid)) {
+		// avoid cycles in pid tree by looking at visited set
+		if pidsVisited.Add(int(childProcess.Pid)) {
+			processHandle, considerChild, signalsToSend, err := checkChildProcess(childProcess, noStopExes, noKillExes)
+			if err != nil {
+				if Verbose {
+					Log.Error(err)
+				}
+			}
+			if processHandle != INVALID_HANDLE {
+				if considerChild {
+					grandChildren, err := childProcess.Children()
+					if err != nil {
+						if err == psutil.ErrorNoChildren {
+							// ignore this error
+							err = nil
+						} else {
+							if Verbose {
+								Log.Error(err)
+							}
+						}
+					} else {
+						if grandChildren != nil {
+							for _, grandChildProcess := range grandChildren {
+								subProcessRecords := getProcessTreeRecursive(
+									grandChildProcess,
+									noStopExes,
+									noKillExes,
+									pidsVisited)
+								for _, subProcessRecord := range subProcessRecords {
+									processRecords = append(processRecords, subProcessRecord)
+								}
+							}
+						}
+					}
+					var processRecord = ProcessRecord{
+						processHandle: processHandle, pid: int(childProcess.Pid), signalsToSend: signalsToSend}
+					processRecords = append(processRecords, processRecord)
+				} else {
+					releaseProcess(processHandle)
+				}
+			}
+		}
+	}
+	return processRecords
+}
+
+func getChildProcesses(noStopExes []string, noKillExes []string) (processRecords []ProcessRecord) {
+	// get any child processes that were spawned from our env
+	processes, err := psutil.Processes()
+	if err == nil {
+		if processes != nil {
+			pidsVisited := IntSet{set: make(map[int]bool)}
+			for _, process := range processes {
+				subProcessRecords := getProcessTreeRecursive(
+					process,
+					noStopExes,
+					noKillExes,
+					&pidsVisited)
+				for _, subProcessRecord := range subProcessRecords {
+					processRecords = append(processRecords, subProcessRecord)
+				}
+			}
+		}
+	} else {
+		if Verbose {
+			Log.Error(err)
+		}
+	}
+	return processRecords
+}
+
+func signalChildProcesses(processRecords []ProcessRecord, signalNum int) (numChildrenSignaled int) {
+	// signal child processes
+	numChildrenSignaled = 0
+	expectedNumChildrenSignaled := 0
+	for _, processRecord := range processRecords {
+		sendSignal := false // first assume false
+		switch signalNum {
+		case CTRL_C_SIGNAL:
+			if processRecord.signalsToSend&SEND_CTRL_C_SIGNAL != 0 {
+				sendSignal = true
+			}
+		case CTRL_BREAK_SIGNAL:
+			if processRecord.signalsToSend&SEND_CTRL_BREAK_SIGNAL != 0 {
+				sendSignal = true
+			}
+		case KILL_SIGNAL:
+			if processRecord.signalsToSend&SEND_KILL_SIGNAL != 0 {
+				sendSignal = true
+			}
+		default:
+			Log.Error(errors.New("Unexpected signalNum"))
+		}
+		if sendSignal {
+			expectedNumChildrenSignaled += 1
+			err := signalProcess(processRecord, signalNum)
+			if err == nil {
+				numChildrenSignaled += 1
+			} else {
+				if Verbose {
+					Log.Error(err)
+				}
+			}
+		}
+	}
+	if expectedNumChildrenSignaled > 0 && numChildrenSignaled == 0 {
+		switch signalNum {
+		case CTRL_C_SIGNAL:
+			Log.Error("no child processes sent Ctrl+C signal")
+		case CTRL_BREAK_SIGNAL:
+			Log.Error("no child processes sent Ctrl+Break signal")
+		case KILL_SIGNAL:
+			Log.Error("no child processes killed")
+		default:
+			Log.Error(errors.New("Unexpected signalNum"))
+		}
+	}
+	return numChildrenSignaled
+}
+
+func anyRemainingChildren(processRecords []ProcessRecord) (anyRemaining bool) {
+	anyRemaining = false
+	for _, processRecord := range processRecords {
+		if doesProcessExist(processRecord.processHandle) {
+			anyRemaining = true
+			break
+		}
+	}
+	return anyRemaining
+}
+
+func pollRemainingChildren(processRecords []ProcessRecord, cleanupTime time.Duration) (anyRemaining bool) {
+	anyRemaining = false
+	startTime := time.Now()
+	sleepTime := 250 * time.Millisecond
+	for {
+		continuePolling := false
+		anyRemaining = anyRemainingChildren(processRecords)
+		if anyRemaining && cleanupTime > 0 {
+			time.Sleep(sleepTime)
+			elapsedTime := time.Since(startTime)
+			if elapsedTime < cleanupTime {
+				// exponential back off with limit:
+				// increase sleep time if next elapsedTime is below 1/2 of cleanupTime
+				if elapsedTime+sleepTime*2 < cleanupTime/2 {
+					// exponential back off
+					sleepTime *= 2
+				} else {
+					// use the same sleepTime as before
+				}
+				continuePolling = true
+			}
+		}
+		if !continuePolling {
+			break
+		}
+	}
+	return anyRemaining
+}
+
+func pollKillProcess(processRecord ProcessRecord) (err error) {
+	if doesProcessExist(processRecord.processHandle) {
+		attempts := 0
+		for {
+			continuePolling := false
+			err = killProcess(processRecord)
+			if doesProcessExist(processRecord.processHandle) {
+				if attempts < 30 {
+					continuePolling = true
+				} else {
+					// timed out
+					err = errors.New(
+						fmt.Sprintf("Timed out trying to kill child process, pid %d", processRecord.pid))
+				}
+			}
+			if continuePolling {
+				// don't use exponential back off here
+				// since want to fail out after fixed number of attempts
+				time.Sleep(250 * time.Millisecond)
+				attempts += 1
+			} else {
+				break
+			}
+		}
+	}
+	return err
+}
+
+// ensure our child processes are stopped
+func stopChildProcesses(noStopExes []string, noKillExes []string, cleanupTime time.Duration) (err error) {
+	err = nil            // first assume no error
+	anyRemaining := true // first assume some children
+	totalNumSignaled := 0
+	if canStopChildProcesses() {
+		processRecords := getChildProcesses(noStopExes, noKillExes)
+		// progress from most graceful to most invasive stop signal
+		// if no matching children, then call is a noop
+		numSignaled := signalChildProcesses(processRecords, CTRL_C_SIGNAL)
+		if numSignaled > 0 {
+			totalNumSignaled += numSignaled
+			anyRemaining = pollRemainingChildren(processRecords, cleanupTime)
+		} else {
+			anyRemaining = true
+		}
+		if anyRemaining {
+			numSignaled = signalChildProcesses(processRecords, CTRL_BREAK_SIGNAL)
+			if numSignaled > 0 {
+				totalNumSignaled += numSignaled
+				anyRemaining = pollRemainingChildren(processRecords, cleanupTime)
+			} else {
+				anyRemaining = true
+			}
+			if anyRemaining {
+				numSignaled = signalChildProcesses(processRecords, KILL_SIGNAL)
+				totalNumSignaled += numSignaled
+			}
+		}
+		anyRemaining = pollRemainingChildren(processRecords, 0) // wait zero time, since already waited above
+		releaseProcesses(processRecords)
+	}
+	if anyRemaining && totalNumSignaled == 0 {
+		msg := "No child processes stopped or killed\n"
+		msg += "       " // seven spaces indent
+		msg += "You will need to manually stop or kill them"
+		err = errors.New(msg)
+	}
+	return err
+}
+
+func releaseProcesses(processRecords []ProcessRecord) {
+	for _, processRecord := range processRecords {
+		releaseProcess(processRecord.processHandle)
+	}
+}
+
+func getChildMarkerKey() string {
+	return "RUSH_CHILD_GROUP"
+}
+
+func getChildMarkerValue() string {
+	// place brackets on either side of the marker,
+	// so we only find exact matches
+	return "[" + ChildMarker + "]"
+}
+
+func getChildMarkerRegex() *regexp.Regexp {
+	// match string with one or more [pid_timestamp] values
+	return regexp.MustCompile(getChildMarkerKey() + "=\\[[0-z]+\\]")
+}
+
+func containsMarker(env string) bool {
+	childMarkerRegex := getChildMarkerRegex()
+	childMarkerValue := getChildMarkerValue()
+	match := childMarkerRegex.FindString(env)
+	return strings.Contains(match, childMarkerValue)
+}
+
+var stopOnce sync.Once
+
 // run a command and pass output to c.reader.
 // Note that output returns only after finishing run.
 // This function is mainly borrowed from https://github.com/brentp/gargs .
@@ -441,25 +803,30 @@ func (c *Command) run(opts *Options, tryNumber int) error {
 	var command *exec.Cmd
 	qcmd := fmt.Sprintf(`%s`, c.Cmd)
 	if Verbose {
-		Log.Infof("start  cmd #%d: %s", c.ID, qcmd)
+		Log.Infof("start cmd #%d: %s", c.ID, qcmd)
 	}
 
 	if c.Timeout > 0 {
 		c.ctx, c.ctxCancel = context.WithTimeout(context.Background(), c.Timeout)
-		if isWindows {
-			command = exec.CommandContext(c.ctx, getShell())
-			c.setWindowsCommandFields(command, qcmd)
-		} else {
-			command = exec.CommandContext(c.ctx, getShell(), "-c", qcmd)
-		}
+		command = getCommand(c.ctx, qcmd)
 	} else {
-		if isWindows {
-			command = exec.Command(getShell())
-			c.setWindowsCommandFields(command, qcmd)
-		} else {
-			command = exec.Command(getShell(), "-c", qcmd)
-		}
+		command = getCommand(nil, qcmd)
 	}
+
+	// mark child processes with our pid,
+	// so we can identify them later,
+	// in case we need to signal them
+	childMarkerKey := getChildMarkerKey()
+	childMarkerValue := getChildMarkerValue()
+	priorValue, found := os.LookupEnv(childMarkerKey)
+	if found {
+		// append marker values to sames key, so
+		// we can handle the nested calls case
+		childMarkerValue = priorValue + childMarkerValue
+	}
+	childMarker := fmt.Sprintf("%s=%s", childMarkerKey, childMarkerValue)
+	// command de-dups variables, in favor of later values
+	command.Env = append(os.Environ(), childMarker)
 
 	var pipeStdout io.ReadCloser = nil
 	var err error = nil
@@ -497,6 +864,17 @@ func (c *Command) run(opts *Options, tryNumber int) error {
 				Log.Warningf("cancel cmd #%d: %s", c.ID, c.Cmd)
 			}
 			chErr <- ErrCancelled
+			// ensure we only initiate the stop attempt once,
+			// from all our command threads
+			stopOnce.Do(func() {
+				err = stopChildProcesses(opts.NoStopExes, opts.NoKillExes, opts.CleanupTime)
+				if err != nil {
+					if Verbose {
+						Log.Error(err)
+					}
+					os.Exit(1)
+				}
+			})
 		case <-chCancelMonitor:
 			// default:  // must not use default, if you must use, use for loop
 		}
@@ -639,8 +1017,10 @@ type Options struct {
 	PrintRetryOutput    bool          // print output from retries
 	Timeout             time.Duration // timeout
 	StopOnErr           bool          // stop on any error
+	NoStopExes          []string      // exe names to exclude from stop signal
+	NoKillExes          []string      // exe names to exclude from kill signal
+	CleanupTime         time.Duration // time to allow children to clean up
 	PropExitStatus      bool          // propagate child exit status
-	KillOnCtrlC         bool          // kill child processes on ctrl-c
 	RecordSuccessfulCmd bool          // send successful command to channel
 	Verbose             bool
 }
@@ -666,9 +1046,6 @@ func Run4Output(opts *Options, cancel chan struct{}, chCmdStr chan string) (chan
 			for c := range chCmd {
 				select {
 				case <-cancel:
-					if Verbose {
-						Log.Debugf("cancel receiving finished cmd")
-					}
 					break RECEIVECMD
 				default: // needed
 				}
@@ -809,10 +1186,10 @@ func Run(opts *Options, cancel chan struct{}, chCmdStr chan string) (chan *Comma
 	if opts.RecordSuccessfulCmd {
 		chSuccessfulCmd = make(chan string, opts.Jobs)
 	}
-	done := make(chan int)
+	done := make(chan int, opts.Jobs)
 	var chExitStatus chan int
 	if opts.PropExitStatus {
-		chExitStatus = make(chan int)
+		chExitStatus = make(chan int, opts.Jobs)
 	}
 
 	go func() {
@@ -874,15 +1251,20 @@ func Run(opts *Options, cancel chan struct{}, chCmdStr chan string) (chan *Comma
 							select {
 							case <-cancel: // already closed
 							default:
-								Log.Error("stop on first error(s)")
-								close(cancel)
-								close(chCmd)
-								if opts.RecordSuccessfulCmd {
-									close(chSuccessfulCmd)
-								}
-								if opts.PropExitStatus {
-									close(chExitStatus)
-								}
+								// ensure we only initiate the stop attempt once,
+								// from all our command threads
+								stopOnce.Do(func() {
+									if opts.StopOnErr {
+										Log.Error("stop on first error")
+									}
+									err = stopChildProcesses(opts.NoStopExes, opts.NoKillExes, opts.CleanupTime)
+									if err != nil {
+										if Verbose {
+											Log.Error(err)
+										}
+										os.Exit(1)
+									}
+								})
 								done <- 1
 							}
 
@@ -924,13 +1306,11 @@ func Run(opts *Options, cancel chan struct{}, chCmdStr chan string) (chan *Comma
 			id++
 		}
 		wg.Wait()
-		if !stop {
-			close(chCmd)
-			if opts.RecordSuccessfulCmd {
-				close(chSuccessfulCmd)
-			}
-		}
 
+		close(chCmd)
+		if opts.RecordSuccessfulCmd {
+			close(chSuccessfulCmd)
+		}
 		if opts.PropExitStatus {
 			close(chExitStatus)
 		}

--- a/process/process.go
+++ b/process/process.go
@@ -261,10 +261,12 @@ func (c *Command) getExitStatus(err error) int {
 // On Windows, call shell with /s to allow correct interpretation of quotes
 // from https://github.com/junegunn/fzf/blob/390b49653b441c958b82a0f78d9923aef4c1d9a2/src/util/util_windows.go
 func (c *Command) setWindowsCommandAttr(command *exec.Cmd, qcmd string) {
-	command.SysProcAttr = &syscall.SysProcAttr{
-		HideWindow:    false,
-		CmdLine:       fmt.Sprintf(` /s /c "%s"`, qcmd),
-		CreationFlags: 0,
+	if isWindows {
+		command.SysProcAttr = &syscall.SysProcAttr{
+			HideWindow:    false,
+			CmdLine:       fmt.Sprintf(` /s /c "%s"`, qcmd),
+			CreationFlags: 0,
+		}
 	}
 }
 

--- a/process/process.go
+++ b/process/process.go
@@ -141,7 +141,12 @@ func (c *Command) Run(opts *Options) (chan string, error) {
 		var existedN int
 		// var N uint64
 		for {
-			n, readErr = c.reader.Read(buf)
+			if c.reader != nil {
+				n, readErr = c.reader.Read(buf)
+			} else {
+				n = 0
+				readErr = io.EOF
+			}
 
 			existedN = b.Len()
 			b.Write(buf[0:n])

--- a/process/process.go
+++ b/process/process.go
@@ -30,7 +30,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
-    "sort"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -75,7 +75,7 @@ type Command struct {
 	Err      error         // Error
 	Duration time.Duration // runtime
 
-	dryrun bool
+	dryrun     bool
 	exitStatus int
 }
 
@@ -291,7 +291,7 @@ func killWindowsProcessTreeRecursive(childProcess *psutil.Process) {
 			}
 			Log.Infof("%s", out)
 		}
-		
+
 		if !isProcessRunning(int(childProcess.Pid)) {
 			break
 		} else {
@@ -337,7 +337,7 @@ func (c *Command) run(opts *Options) error {
 			command = exec.Command(getShell(), "-c", qcmd)
 		}
 	}
-    
+
 	pipeStdout, err := command.StdoutPipe()
 	if err != nil {
 		return errors.Wrapf(err, "get stdout pipe of cmd #%d: %s", c.ID, c.Cmd)
@@ -513,7 +513,7 @@ func Run4Output(opts *Options, cancel chan struct{}, chCmdStr chan string) (chan
 	chCmd, chSuccessfulCmd, doneChCmd, chExitStatus := Run(opts, cancel, chCmdStr)
 	chOut := make(chan string, opts.Jobs)
 	done := make(chan int)
-    
+
 	go func() {
 		var wg sync.WaitGroup
 
@@ -620,7 +620,7 @@ func Run4Output(opts *Options, cancel chan struct{}, chCmdStr chan string) (chan
 
 			wg.Done()
 		}
-        
+
 		<-doneChCmd
 		wg.Wait()
 		close(chOut)
@@ -635,7 +635,7 @@ func Run4Output(opts *Options, cancel chan struct{}, chCmdStr chan string) (chan
 
 // write strings and report done
 func combineWorker(input <-chan string, output chan<- string, wg *sync.WaitGroup) {
-    defer wg.Done()
+	defer wg.Done()
 	for val := range input {
 		output <- val
 	}
@@ -648,7 +648,7 @@ func combine(inputs []<-chan string, output chan<- string) {
 		for _, input := range inputs {
 			group.Add(1)
 			go combineWorker(input, output, group)
-			group.Wait()  // preserve input order
+			group.Wait() // preserve input order
 		}
 		close(output)
 	}()
@@ -713,7 +713,7 @@ func Run(opts *Options, cancel chan struct{}, chCmdStr chan string) (chan *Comma
 				for {
 					ch, err := command.Run(opts)
 					if err != nil { // fail to run
-                        if chances == 0 || opts.StopOnErr {
+						if chances == 0 || opts.StopOnErr {
 							// print final output
 							outputsToPrint = append(outputsToPrint, ch)
 							Log.Error(err)

--- a/process/process_others.go
+++ b/process/process_others.go
@@ -26,9 +26,17 @@ import (
 	"os/exec"
 )
 
-func (c *Command) setWindowsCommandAttr(command *exec.Cmd, qcmd string) {
+func KillWindowsChildProcesses() (childrenWereStopped bool) {
 	if isWindows {
-		panic("should have called process_windows.go setWindowsCommandAttr()!")
+		panic("should have called process_windows.go KillWindowsChildProcesses()!")
+	} else {
+		// noop for all platforms except windows
+	}
+}
+
+func (c *Command) setWindowsCommandFields(command *exec.Cmd, qcmd string) {
+	if isWindows {
+		panic("should have called process_windows.go setWindowsCommandFields()!")
 	} else {
 		// noop for all platforms except windows
 	}

--- a/process/process_others.go
+++ b/process/process_others.go
@@ -1,4 +1,4 @@
-// +build windows
+// +build !windows
 
 // Copyright © 2017 Wei Shen <shenwei356@gmail.com>
 //
@@ -23,20 +23,13 @@
 package process
 
 import (
-	"fmt"
 	"os/exec"
-	"syscall"
 )
 
-// from https://github.com/junegunn/fzf/blob/390b49653b441c958b82a0f78d9923aef4c1d9a2/src/util/util_windows.go
 func (c *Command) setWindowsCommandAttr(command *exec.Cmd, qcmd string) {
 	if isWindows {
-		command.SysProcAttr = &syscall.SysProcAttr{
-			HideWindow:    false,
-			CmdLine:       fmt.Sprintf(` /s /c "%s"`, qcmd),
-			CreationFlags: 0,
-		}
-	} else{
-		panic("should have called process_others.go setWindowsCommandAttr()!")
+		panic("should have called process_windows.go setWindowsCommandAttr()!")
+	} else {
+		// noop for all platforms except windows
 	}
 }

--- a/process/process_others.go
+++ b/process/process_others.go
@@ -23,21 +23,132 @@
 package process
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
 	"os/exec"
+	"strconv"
 )
 
-func KillWindowsChildProcesses() (childrenWereStopped bool) {
-	if isWindows {
-		panic("should have called process_windows.go KillWindowsChildProcesses()!")
+func getProcess(pid int) (processHandle int, processExists bool, accessGranted bool, err error) {
+	// just use the pid as the process handle
+	processHandle = pid
+	// check if the process exists
+	processExists = doesProcessExist(processHandle)
+	// check if we have access to send a signal to the process
+	pidStr := strconv.Itoa(pid)
+	_, err = exec.Command("kill", "-0", pidStr).Output()
+	if err == nil {
+		accessGranted = true
 	} else {
-		// noop for all platforms except windows
+		accessGranted = false
+	}
+	return processHandle, processExists, accessGranted, err
+}
+
+func releaseProcess(processHandle int) {
+	// nothing to release
+}
+
+func doesProcessExist(processHandle int) (processExists bool) {
+	processExists = false
+	// check if the process exists
+	// just use the process handle as the pid
+	pid := processHandle
+	pidStr := strconv.Itoa(pid)
+	_, err := exec.Command("ps", "-p", pidStr).Output()
+	if err == nil {
+		processExists = true
+	}
+	return processExists
+}
+
+func getShell() (shell string) {
+	shell = os.Getenv("SHELL")
+	if shell == "" {
+		shell = "sh"
+	}
+	return shell
+}
+
+func getCommand(ctx context.Context, qcmd string) *exec.Cmd {
+	if ctx != nil {
+		return exec.CommandContext(ctx, getShell(), "-c", qcmd)
+	} else {
+		return exec.Command(getShell(), "-c", qcmd)
 	}
 }
 
-func (c *Command) setWindowsCommandFields(command *exec.Cmd, qcmd string) {
-	if isWindows {
-		panic("should have called process_windows.go setWindowsCommandFields()!")
-	} else {
-		// noop for all platforms except windows
+func considerPid(pid int) bool {
+	// skip our process and the init process
+	return pid != os.Getpid() && pid != 1
+}
+
+func getSignalsToSend(childProcessName string, noStopExes []string, noKillExes []string) (signalsToSend int, err error) {
+	signalsToSend = SEND_NO_SIGNAL // first assume no signal
+	canSendStopSignal, err := canSendSignal(childProcessName, noStopExes)
+	if err == nil {
+		if canSendStopSignal {
+			signalsToSend |= SEND_CTRL_C_SIGNAL
+			// Ctrl+Break is Windows only, so it is not signaled
+		}
+		canSendKillSignal, err := canSendSignal(childProcessName, noKillExes)
+		if err == nil {
+			if canSendKillSignal {
+				signalsToSend |= SEND_KILL_SIGNAL
+			}
+		}
 	}
+	return signalsToSend, err
+}
+
+func doesChildHaveMarker(processHandle int) (hasMarker bool, err error) {
+	// the process handle is the pid
+	envCmd := fmt.Sprintf("xargs -0 -n 1 < /proc/%d/environ", processHandle)
+	env, err := exec.Command(getShell(), "-c", envCmd).Output()
+	if err == nil {
+		hasMarker = containsMarker(string(env))
+	} else {
+		hasMarker = false
+	}
+	return hasMarker, err
+}
+
+func _signalProcess(pid int, signalStr string) (err error) {
+	pidStr := strconv.Itoa(pid)
+	out, err := exec.Command("kill", signalStr, pidStr).Output()
+	if Verbose {
+		Log.Infof("ran kill %s %s, waiting for response", signalStr, pidStr)
+		if err != nil {
+			Log.Error(err)
+		}
+		Log.Infof("%s", out)
+	}
+	return err
+}
+
+func killProcess(processRecord ProcessRecord) error {
+	// -9 means send kill signal
+	return _signalProcess(processRecord.pid, "-9")
+}
+
+func signalProcess(processRecord ProcessRecord, signalNum int) (err error) {
+	switch signalNum {
+	case CTRL_C_SIGNAL:
+		// -SIGINT means send Ctrl+C signal
+		err = _signalProcess(processRecord.pid, "-SIGINT")
+	case CTRL_BREAK_SIGNAL:
+		// nothing to do since Ctrl+Break is Windows only
+		err = nil
+	case KILL_SIGNAL:
+		err = pollKillProcess(processRecord)
+	default:
+		err = errors.New("Unexpected signalNum")
+	}
+	return err
+}
+
+func canStopChildProcesses() bool {
+	return true
 }

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -24,19 +24,463 @@ package process
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
 	"syscall"
+	"time"
+	"unicode/utf16"
+	"unsafe"
+
+	"github.com/elastic/go-windows"
+	"github.com/pkg/errors"
+	psutil "github.com/shirou/gopsutil/process"
 )
 
+// from https://github.com/elastic/go-windows/zsyscall_windows.go
+// Do the interface allocations only once for common
+// Errno values.
+const (
+	errnoERROR_IO_PENDING = 997
+)
+
+var (
+	errERROR_IO_PENDING error = syscall.Errno(errnoERROR_IO_PENDING)
+)
+
+// errnoErr returns common boxed Errno values, to prevent
+// allocations at runtime.
+func errnoErr(e syscall.Errno) error {
+	switch e {
+	case 0:
+		return nil
+	case errnoERROR_IO_PENDING:
+		return errERROR_IO_PENDING
+	}
+	// TODO: add more here, after collecting data on the common
+	// error values see on Windows. (perhaps when running
+	// all.bat?)
+	return e
+}
+
+func openProcess(pid int) (handle syscall.Handle, err error) {
+	// PROCESS_QUERY_INFORMATION is needed to call GetExitCodeProcess()
+	// PROCESS_VM_READ is needed to call ReadProcessMemory()
+	handle, err = syscall.OpenProcess(
+		syscall.PROCESS_QUERY_INFORMATION|windows.PROCESS_VM_READ, false, uint32(pid))
+	if handle == 0 {
+		handle = syscall.InvalidHandle
+	}
+	return handle, err
+}
+
+func getProcessBasicInformation(handle syscall.Handle) (pbi windows.ProcessBasicInformationStruct, err error) {
+	actualSize, err := windows.NtQueryInformationProcess(handle, windows.ProcessBasicInformation, unsafe.Pointer(&pbi), uint32(windows.SizeOfProcessBasicInformationStruct))
+	if actualSize < uint32(windows.SizeOfProcessBasicInformationStruct) {
+		return pbi, errors.New("bad size for PROCESS_BASIC_INFORMATION")
+	}
+	return pbi, err
+}
+
+func getUserProcessParams(handle syscall.Handle, pbi windows.ProcessBasicInformationStruct) (params RtlUserProcessParameters, err error) {
+	const is32bitProc = unsafe.Sizeof(uintptr(0)) == 4
+
+	// Offset of params field within PEB structure.
+	// This structure is different in 32 and 64 bit.
+	paramsOffset := 0x20
+	if is32bitProc {
+		paramsOffset = 0x10
+	}
+
+	// Read the PEB from the target process memory
+	pebSize := paramsOffset + 8
+	peb := make([]byte, pebSize)
+	nRead, err := windows.ReadProcessMemory(handle, pbi.PebBaseAddress, peb)
+	if err != nil {
+		return params, err
+	}
+	if nRead != uintptr(pebSize) {
+		return params, errors.Errorf("PEB: short read (%d/%d)", nRead, pebSize)
+	}
+
+	// Get the RTL_USER_PROCESS_PARAMETERS struct pointer from the PEB
+	paramsAddr := *(*uintptr)(unsafe.Pointer(&peb[paramsOffset]))
+
+	// Read the RTL_USER_PROCESS_PARAMETERS from the target process memory
+	paramsBuf := make([]byte, SizeOfRtlUserProcessParameters)
+	nRead, err = windows.ReadProcessMemory(handle, paramsAddr, paramsBuf)
+	if err != nil {
+		return params, err
+	}
+	if nRead != uintptr(SizeOfRtlUserProcessParameters) {
+		return params, errors.Errorf("RTL_USER_PROCESS_PARAMETERS: short read (%d/%d)", nRead, SizeOfRtlUserProcessParameters)
+	}
+
+	params = *(*RtlUserProcessParameters)(unsafe.Pointer(&paramsBuf[0]))
+	return params, nil
+}
+
+// from https://github.com/elastic/go-windows/utf16.go, but without null terminal truncation
+// UTF16BytesToString returns a string that is decoded from the UTF-16 bytes.
+// The byte slice must be of even length otherwise an error will be returned.
+func UTF16BytesToString(b []byte) (string, error) {
+	if len(b)%2 != 0 {
+		return "", fmt.Errorf("slice must have an even length (length=%d)", len(b))
+	}
+
+	s := make([]uint16, len(b)/2)
+	for i := range s {
+		s[i] = uint16(b[i*2]) + uint16(b[(i*2)+1])<<8
+	}
+
+	return string(utf16.Decode(s)), nil
+}
+
+// from https://github.com/elastic/go-windows/ntdll.go, but with Environment added
+// RtlUserProcessParameters is Go's equivalent for the
+// _RTL_USER_PROCESS_PARAMETERS struct.
+// A few undocumented fields are exposed.
+type RtlUserProcessParameters struct {
+	Reserved1 [16]byte
+	Reserved2 [5]uintptr
+
+	// <undocumented>
+	CurrentDirectoryPath   windows.UnicodeString
+	CurrentDirectoryHandle uintptr
+	DllPath                windows.UnicodeString
+	// </undocumented>
+
+	ImagePathName windows.UnicodeString
+	CommandLine   windows.UnicodeString
+	Environment   uintptr
+}
+
+// MemoryBasicInformation is Go's equivalent for the
+// _MEMORY_BASIC_INFORMATION struct.
+type MemoryBasicInformation struct {
+	BaseAddress       uintptr
+	AllocationBase    uintptr
+	AllocationProtect uint32
+	RegionSize        uintptr
+	State             uint32
+	Protect           uint32
+	Type              uint32
+}
+
+const (
+	// SizeOfRtlUserProcessParameters gives the size
+	// of the RtlUserProcessParameters struct.
+	SizeOfRtlUserProcessParameters = unsafe.Sizeof(RtlUserProcessParameters{})
+
+	// SizeOfMemoryBasicInformation gives the size
+	// of the MemoryBasicInformation struct.
+	SizeOfMemoryBasicInformation = unsafe.Sizeof(MemoryBasicInformation{})
+)
+
+var (
+	modkernel32        = syscall.NewLazyDLL("kernel32.dll")
+	procVirtualQueryEx = modkernel32.NewProc("VirtualQueryEx")
+)
+
+func _VirtualQueryEx(handle syscall.Handle, address uintptr, buffer uintptr, size uintptr, nRead *uintptr) (err error) {
+	r1, _, e1 := syscall.Syscall6(procVirtualQueryEx.Addr(), 4, uintptr(handle), uintptr(address), uintptr(buffer), uintptr(size),
+		0, 0)
+	if r1 == 0 {
+		if e1 != 0 {
+			err = errnoErr(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	*nRead = r1
+	return err
+}
+
+func VirtualQueryEx(handle syscall.Handle, baseAddress uintptr, dest []byte) (nRead uintptr, err error) {
+	n := len(dest)
+	if n == 0 {
+		return 0, nil
+	}
+	if err = _VirtualQueryEx(handle, baseAddress, uintptr(unsafe.Pointer(&dest[0])), uintptr(n), &nRead); err != nil {
+		return 0, err
+	}
+	return nRead, nil
+}
+
+func getProcessEnv(handle syscall.Handle, params RtlUserProcessParameters) (env string, err error) {
+	// get the size of the env variables block
+	mbiBuf := make([]byte, SizeOfMemoryBasicInformation)
+	nRead, err := VirtualQueryEx(handle, params.Environment, mbiBuf)
+	if err != nil {
+		return env, err
+	}
+	if nRead != uintptr(SizeOfMemoryBasicInformation) {
+		return env, errors.Errorf("MEMORY_BASIC_INFORMATION: short read (%d/%d)", nRead, SizeOfMemoryBasicInformation)
+	}
+
+	mbi := *(*MemoryBasicInformation)(unsafe.Pointer(&mbiBuf[0]))
+
+	// read the content of the env variables block
+	envSize := mbi.RegionSize - (uintptr(params.Environment) - uintptr(mbi.BaseAddress))
+
+	envBuf := make([]byte, envSize)
+	nRead, err = windows.ReadProcessMemory(handle, params.Environment, envBuf)
+	if err != nil {
+		return env, err
+	}
+	if nRead != uintptr(envSize) {
+		return env, errors.Errorf("Environment string: short read: (%d/%d)", nRead, envSize)
+	}
+
+	env, err = UTF16BytesToString(envBuf)
+	if err != nil {
+		return env, err
+	}
+
+	return env, nil
+}
+
+func getChildMarkerKey() string {
+	return "RUSH_CHILD_GROUP"
+}
+
+func getChildMarkerValue() string {
+	// place brackets on either side of pid integer,
+	// so we only find exact matches
+	return fmt.Sprintf("[%d]", os.Getpid())
+}
+
+func getChildMarkerRegex() *regexp.Regexp {
+	// match string with one or more [pid] values
+	return regexp.MustCompile(getChildMarkerKey() + "=[\\[\\d+\\]]+")
+}
+
+func doesChildHaveMarker(handle syscall.Handle) (childHasMarker bool, err error) {
+	childHasMarker = false
+	pbi, err := getProcessBasicInformation(handle)
+	if err == nil {
+		userProcParams, err := getUserProcessParams(handle, pbi)
+		if err == nil {
+			env, err := getProcessEnv(handle, userProcParams)
+			if err == nil {
+				childMarkerRegex := getChildMarkerRegex()
+				childMarkerValue := getChildMarkerValue()
+				match := childMarkerRegex.FindString(env)
+				childHasMarker = strings.Contains(match, childMarkerValue)
+			}
+		}
+	}
+	return childHasMarker, err
+}
+
+const (
+	// from https://docs.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-getexitcodeprocess
+	STILL_ACTIVE = 259
+)
+
+func killWindowsChildProcess(handle syscall.Handle, pid int) (err error) {
+	var state uint32
+	err = syscall.GetExitCodeProcess(handle, &state)
+	if err == nil {
+		if state == STILL_ACTIVE { // process still exists
+			attempts := 1
+			for {
+				if Verbose {
+					Log.Infof("taskkill /t /f /pid %s", strconv.Itoa(pid))
+				}
+
+				out, err := exec.Command("taskkill", "/t", "/f", "/pid", strconv.Itoa(pid)).Output()
+
+				if Verbose {
+					if err != nil {
+						Log.Error(err)
+					}
+					Log.Infof("%s", out)
+				}
+
+				err = syscall.GetExitCodeProcess(handle, &state)
+				if err == nil {
+					if state != STILL_ACTIVE { // process no longer exists
+						break
+					}
+				} else {
+					if Verbose {
+						Log.Error(err)
+					}
+				}
+				time.Sleep(10 * time.Millisecond)
+				attempts += 1
+				if attempts > 30 {
+					// timed out
+					timeoutMsg := fmt.Sprintf("Timed out trying to kill child process, pid %d", pid)
+					err = errors.New(timeoutMsg)
+					break
+				}
+			}
+		}
+	} else {
+		if Verbose {
+			Log.Error(err)
+		}
+	}
+	return err
+}
+
+func checkWindowsChildProcess(childProcess *psutil.Process) (handle syscall.Handle, considerChild bool, err error) {
+	// ignore errors from openProcess, since child may no longer exist
+	var err2 error
+	handle, err2 = openProcess(int(childProcess.Pid))
+	if err2 == nil {
+		if handle != syscall.InvalidHandle {
+			considerChild, err = doesChildHaveMarker(handle)
+		} else {
+			// failed to open child process, so don't consider it
+			considerChild = false
+		}
+	} else {
+		// child no longer exists, so don't consider it
+		considerChild = false
+	}
+	return handle, considerChild, err
+}
+
+// from https://softwareengineering.stackexchange.com/questions/177428/sets-data-structure-in-golang
+type IntSet struct {
+	set map[int]bool
+}
+
+func (set *IntSet) Add(i int) bool {
+	_, found := set.set[i]
+	set.set[i] = true
+	return !found //False if it existed already
+}
+
+// stop process tree in bottom up order
+func killWindowsProcessTreeRecursive(
+	childProcess *psutil.Process,
+	checkBeforeDescending bool,
+	pidsVisited *IntSet,
+) (childrenWereStopped bool) {
+	childrenWereStopped = true // first assume true
+	// skip our process, the System process, and the Idle process
+	if childProcess.Pid != int32(os.Getpid()) &&
+		childProcess.Pid != 0 &&
+		childProcess.Pid != 4 {
+		// avoid cycles in pid tree by looking at visited set
+		if pidsVisited.Add(int(childProcess.Pid)) {
+			handle := syscall.InvalidHandle
+			considerChild := true // first assume true
+			var err error
+			if checkBeforeDescending {
+				handle, considerChild, err = checkWindowsChildProcess(childProcess)
+				if err != nil {
+					childrenWereStopped = false
+					if Verbose {
+						Log.Error(err)
+					}
+				}
+			}
+			if considerChild {
+				grandChildren, err := childProcess.Children()
+				if err == nil {
+					if grandChildren != nil {
+						for _, grandChildProcess := range grandChildren {
+							childrenWereStopped = childrenWereStopped && killWindowsProcessTreeRecursive(
+								grandChildProcess,
+								checkBeforeDescending,
+								pidsVisited)
+						}
+					}
+				} else {
+					childrenWereStopped = false
+					if Verbose {
+						Log.Error(err)
+					}
+				}
+				// only kill child process if we were able to kill its children
+				if childrenWereStopped {
+					if !checkBeforeDescending {
+						handle, considerChild, err = checkWindowsChildProcess(childProcess)
+						if err != nil {
+							childrenWereStopped = false
+							if Verbose {
+								Log.Error(err)
+							}
+						}
+					}
+					if considerChild {
+						if handle != syscall.InvalidHandle {
+							err = killWindowsChildProcess(handle, int(childProcess.Pid))
+							if err != nil {
+								childrenWereStopped = false
+								if Verbose {
+									Log.Error(err)
+								}
+							}
+						}
+					}
+				}
+			}
+			if handle != syscall.InvalidHandle {
+				syscall.CloseHandle(handle)
+			}
+		}
+	}
+	return childrenWereStopped
+}
+
+// ensure our child processes go away
+func KillWindowsChildProcesses() (childrenWereStopped bool) {
+	// stop any child processes that were spawned from our env
+	childrenWereStopped = true // first assume true
+	processes, err := psutil.Processes()
+	if err == nil {
+		if processes != nil {
+			pidsVisited := IntSet{set: make(map[int]bool)}
+			for _, process := range processes {
+				// specify checkBeforeDescending true here,
+				// since only want to descend if process is one of our children
+				childrenWereStopped = childrenWereStopped && killWindowsProcessTreeRecursive(
+					process,
+					true, // checkBeforeDescending
+					&pidsVisited)
+			}
+		}
+	} else {
+		childrenWereStopped = false
+		if Verbose {
+			Log.Error(err)
+		}
+	}
+
+	return childrenWereStopped
+}
+
 // from https://github.com/junegunn/fzf/blob/390b49653b441c958b82a0f78d9923aef4c1d9a2/src/util/util_windows.go
-func (c *Command) setWindowsCommandAttr(command *exec.Cmd, qcmd string) {
+func (c *Command) setWindowsCommandFields(command *exec.Cmd, qcmd string) {
 	if isWindows {
 		command.SysProcAttr = &syscall.SysProcAttr{
 			HideWindow:    false,
 			CmdLine:       fmt.Sprintf(` /s /c "%s"`, qcmd),
 			CreationFlags: 0,
 		}
+		// mark child processes with our pid,
+		// so we can identify them later,
+		// in case we need to kill them
+		childMarkerKey := getChildMarkerKey()
+		childMarkerValue := getChildMarkerValue()
+		priorValue, found := os.LookupEnv(childMarkerKey)
+		if found {
+			// append marker values to sames key, so
+			// we can handle the nested calls case
+			childMarkerValue = priorValue + childMarkerValue
+		}
+		childMarker := fmt.Sprintf("%s=%s", childMarkerKey, childMarkerValue)
+		// command de-dups variables, in favor of later values
+		command.Env = append(os.Environ(), childMarker)
 	} else {
-		panic("should have called process_others.go setWindowsCommandAttr()!")
+		panic("should have called process_others.go setWindowsCommandFields()!")
 	}
 }

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -36,7 +36,7 @@ func (c *Command) setWindowsCommandAttr(command *exec.Cmd, qcmd string) {
 			CmdLine:       fmt.Sprintf(` /s /c "%s"`, qcmd),
 			CreationFlags: 0,
 		}
-	} else{
+	} else {
 		panic("should have called process_others.go setWindowsCommandAttr()!")
 	}
 }

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -23,20 +23,45 @@
 package process
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
-	"regexp"
+	"runtime"
 	"strconv"
-	"strings"
 	"syscall"
-	"time"
 	"unicode/utf16"
 	"unsafe"
 
 	"github.com/elastic/go-windows"
+	"github.com/palantir/stacktrace"
 	"github.com/pkg/errors"
-	psutil "github.com/shirou/gopsutil/process"
+)
+
+var is32bitRush bool = runtime.GOARCH == "386"
+
+var (
+	modntdll                = syscall.NewLazyDLL("ntdll.dll")
+	procNtReadVirtualMemory = modntdll.NewProc("NtReadVirtualMemory")
+
+	modkernel32                  = syscall.NewLazyDLL("kernel32.dll")
+	procCreateRemoteThread       = modkernel32.NewProc("CreateRemoteThread")
+	procGetSystemWow64DirectoryW = modkernel32.NewProc("GetSystemWow64DirectoryW")
+	procIsWow64Process           = modkernel32.NewProc("IsWow64Process")
+	procOpenProcess              = modkernel32.NewProc("OpenProcess")
+	procVirtualAllocEx           = modkernel32.NewProc("VirtualAllocEx")
+	procVirtualFreeEx            = modkernel32.NewProc("VirtualFreeEx")
+	procVirtualQueryEx           = modkernel32.NewProc("VirtualQueryEx")
+	procWaitForSingleObject      = modkernel32.NewProc("WaitForSingleObject")
+	procWriteProcessMemory       = modkernel32.NewProc("WriteProcessMemory")
+
+	// for VirtualAllocEx
+	MEM_COMMIT             = 0x1000
+	MEM_RESERVE            = 0x2000
+	PAGE_EXECUTE_READWRITE = 0x40
+
+	// for VirtualAllocFree
+	MEM_RELEASE = 0x8000
 )
 
 // from https://github.com/elastic/go-windows/zsyscall_windows.go
@@ -65,26 +90,147 @@ func errnoErr(e syscall.Errno) error {
 	return e
 }
 
-func openProcess(pid int) (handle syscall.Handle, err error) {
-	// PROCESS_QUERY_INFORMATION is needed to call GetExitCodeProcess()
-	// PROCESS_VM_READ is needed to call ReadProcessMemory()
-	handle, err = syscall.OpenProcess(
-		syscall.PROCESS_QUERY_INFORMATION|windows.PROCESS_VM_READ, false, uint32(pid))
-	if handle == 0 {
-		handle = syscall.InvalidHandle
-	}
-	return handle, err
+const (
+	PROCESS_CREATE_THREAD = 2
+	PROCESS_VM_OPERATION  = 8
+	PROCESS_VM_WRITE      = 32
+
+	ERROR_ACCESS_DENIED     = 5
+	ERROR_INVALID_PARAMETER = 87
+)
+
+func getNtErr(status uint32) error {
+	ntStatus := windows.NTStatus(status)
+	return stacktrace.PropagateWithCode(ntStatus, stacktrace.ErrorCode(ntStatus), "")
 }
 
-func getProcessBasicInformation(handle syscall.Handle) (pbi windows.ProcessBasicInformationStruct, err error) {
-	actualSize, err := windows.NtQueryInformationProcess(handle, windows.ProcessBasicInformation, unsafe.Pointer(&pbi), uint32(windows.SizeOfProcessBasicInformationStruct))
+func getSyscallErr(e1 syscall.Errno) error {
+	var simpleErr error = nil
+	var errorCode int = 0
+	if e1 != 0 {
+		simpleErr = errnoErr(e1)
+		errorCode = int(e1)
+	} else {
+		simpleErr = syscall.EINVAL
+		errorCode = int(syscall.EINVAL)
+	}
+	return stacktrace.PropagateWithCode(simpleErr, stacktrace.ErrorCode(errorCode), "")
+}
+
+func isAccessDeniedError(err error) bool {
+	if err != nil {
+		return stacktrace.GetCode(err) == ERROR_ACCESS_DENIED
+	} else {
+		return false
+	}
+}
+
+// from golang.org/x/sys/windows/zsyscall_windows.go
+func openProcess(da uint32, inheritHandle bool, pid uint32) (handle syscall.Handle, err error) {
+	var _p0 uint32
+	if inheritHandle {
+		_p0 = 1
+	} else {
+		_p0 = 0
+	}
+	r0, _, e1 := syscall.Syscall(procOpenProcess.Addr(), 3, uintptr(da), uintptr(_p0), uintptr(pid))
+	handle = syscall.Handle(r0)
+	if handle == 0 {
+		err = getSyscallErr(e1)
+	}
+	return
+}
+
+func getProcess(pid int) (processHandle int, processExists bool, accessGranted bool, err error) {
+	processExists = false
+	accessGranted = false
+	var access uint32
+	// All these are needed for CreateRemoteThread()
+	// PROCESS_QUERY_INFORMATION is needed to call GetExitCodeProcess()
+	// PROCESS_VM_READ is needed to read process memory
+	access = PROCESS_CREATE_THREAD | syscall.PROCESS_QUERY_INFORMATION |
+		PROCESS_VM_OPERATION | PROCESS_VM_WRITE | windows.PROCESS_VM_READ
+
+	winProcessHandle, err := openProcess(
+		access, false, uint32(pid))
+	if winProcessHandle == syscall.InvalidHandle || winProcessHandle == 0 {
+		processHandle = INVALID_HANDLE
+	} else {
+		processHandle = int(winProcessHandle)
+	}
+	if err == nil {
+		processExists = true
+		accessGranted = true
+	} else {
+		// ERROR_ACCESS_DENIED means that we don't have permission to open a handle to the process
+		if !isAccessDeniedError(err) {
+			accessGranted = true
+			// ERROR_INVALID_PARAMETER means that the process does not exist
+			if stacktrace.GetCode(err) != ERROR_INVALID_PARAMETER { // if process exists
+				processExists = true
+			}
+		} else { // access denied
+			// leave accessGranted = false, from initial value
+			processExists = true
+		}
+	}
+	return processHandle, processExists, accessGranted, err
+}
+
+func releaseProcess(processHandle int) {
+	syscall.CloseHandle(syscall.Handle(processHandle))
+}
+
+func doesProcessExist(processHandle int) (processExists bool) {
+	processExists = false
+	var state uint32
+	winProcessHandle := syscall.Handle(processHandle)
+	err := syscall.GetExitCodeProcess(winProcessHandle, &state)
+	if err == nil {
+		if state == STILL_ACTIVE { // process still exists
+			processExists = true
+		}
+	}
+	return processExists
+}
+
+func waitForSingleObject(handle syscall.Handle, waitMilliseconds uint32) (event uint32, err error) {
+	r0, _, e1 := syscall.Syscall(procWaitForSingleObject.Addr(), 2, uintptr(handle), uintptr(waitMilliseconds), 0)
+	event = uint32(r0)
+	if event == 0xffffffff {
+		err = getSyscallErr(e1)
+	}
+	return
+}
+
+func _ntReadVirtualMemory(handle syscall.Handle, baseAddress uintptr, buffer uintptr, size uintptr, numRead *uintptr) (ntStatus uint32) {
+	r0, _, _ := procNtReadVirtualMemory.Call(
+		uintptr(handle), uintptr(baseAddress), uintptr(buffer), uintptr(size), uintptr(unsafe.Pointer(numRead)))
+	ntStatus = uint32(r0)
+	return
+}
+
+func ntReadVirtualMemory(handle syscall.Handle, baseAddress uintptr, dest []byte) (numRead uintptr, err error) {
+	n := len(dest)
+	if n == 0 {
+		return 0, nil
+	}
+	status := _ntReadVirtualMemory(handle, baseAddress, uintptr(unsafe.Pointer(&dest[0])), uintptr(n), &numRead)
+	if status != 0 {
+		return numRead, getNtErr(status)
+	}
+	return numRead, nil
+}
+
+func getProcessBasicInformation(processHandle syscall.Handle) (pbi windows.ProcessBasicInformationStruct, err error) {
+	actualSize, err := windows.NtQueryInformationProcess(processHandle, windows.ProcessBasicInformation, unsafe.Pointer(&pbi), uint32(windows.SizeOfProcessBasicInformationStruct))
 	if actualSize < uint32(windows.SizeOfProcessBasicInformationStruct) {
-		return pbi, errors.New("bad size for PROCESS_BASIC_INFORMATION")
+		return pbi, errors.New("Bad size for PROCESS_BASIC_INFORMATION")
 	}
 	return pbi, err
 }
 
-func getUserProcessParams(handle syscall.Handle, pbi windows.ProcessBasicInformationStruct) (params RtlUserProcessParameters, err error) {
+func getUserProcessParams(processHandle syscall.Handle, pbi windows.ProcessBasicInformationStruct) (params RtlUserProcessParameters, err error) {
 	const is32bitProc = unsafe.Sizeof(uintptr(0)) == 4
 
 	// Offset of params field within PEB structure.
@@ -97,7 +243,7 @@ func getUserProcessParams(handle syscall.Handle, pbi windows.ProcessBasicInforma
 	// Read the PEB from the target process memory
 	pebSize := paramsOffset + 8
 	peb := make([]byte, pebSize)
-	nRead, err := windows.ReadProcessMemory(handle, pbi.PebBaseAddress, peb)
+	nRead, err := ntReadVirtualMemory(processHandle, pbi.PebBaseAddress, peb)
 	if err != nil {
 		return params, err
 	}
@@ -110,7 +256,7 @@ func getUserProcessParams(handle syscall.Handle, pbi windows.ProcessBasicInforma
 
 	// Read the RTL_USER_PROCESS_PARAMETERS from the target process memory
 	paramsBuf := make([]byte, SizeOfRtlUserProcessParameters)
-	nRead, err = windows.ReadProcessMemory(handle, paramsAddr, paramsBuf)
+	nRead, err = ntReadVirtualMemory(processHandle, paramsAddr, paramsBuf)
 	if err != nil {
 		return params, err
 	}
@@ -125,7 +271,7 @@ func getUserProcessParams(handle syscall.Handle, pbi windows.ProcessBasicInforma
 // from https://github.com/elastic/go-windows/utf16.go, but without null terminal truncation
 // UTF16BytesToString returns a string that is decoded from the UTF-16 bytes.
 // The byte slice must be of even length otherwise an error will be returned.
-func UTF16BytesToString(b []byte) (string, error) {
+func utf16BytesToString(b []byte) (string, error) {
 	if len(b)%2 != 0 {
 		return "", fmt.Errorf("slice must have an even length (length=%d)", len(b))
 	}
@@ -179,40 +325,100 @@ const (
 	SizeOfMemoryBasicInformation = unsafe.Sizeof(MemoryBasicInformation{})
 )
 
-var (
-	modkernel32        = syscall.NewLazyDLL("kernel32.dll")
-	procVirtualQueryEx = modkernel32.NewProc("VirtualQueryEx")
-)
+func getSystemWow64DirectoryW(buffer uintptr, size uintptr) error {
+	r1, _, e1 := procGetSystemWow64DirectoryW.Call(
+		uintptr(buffer),
+		uintptr(size))
+	if int(r1) == 0 {
+		return e1
+	}
+	return nil
+}
 
-func _VirtualQueryEx(handle syscall.Handle, address uintptr, buffer uintptr, size uintptr, nRead *uintptr) (err error) {
-	r1, _, e1 := syscall.Syscall6(procVirtualQueryEx.Addr(), 4, uintptr(handle), uintptr(address), uintptr(buffer), uintptr(size),
+func isWow64Process(processHandle syscall.Handle) (bool, error) {
+	var wow64Process bool
+	r1, _, e1 := procIsWow64Process.Call(
+		uintptr(processHandle),
+		uintptr(unsafe.Pointer(&wow64Process)))
+	if int(r1) == 0 {
+		return false, e1
+	}
+	return wow64Process, nil
+}
+
+// from https://github.com/contester/runlib/blob/master/win32/win32_windows.go
+func _createRemoteThread(processHandle syscall.Handle, sa *syscall.SecurityAttributes, stackSize uint32, startAddress uintptr,
+	parameter uintptr, creationFlags uint32) (syscall.Handle, uint32, error) {
+	var threadId uint32
+	r1, _, e1 := syscall.Syscall9(procCreateRemoteThread.Addr(),
+		7,
+		uintptr(processHandle),
+		uintptr(unsafe.Pointer(sa)),
+		uintptr(stackSize),
+		startAddress,
+		parameter,
+		uintptr(creationFlags),
+		uintptr(unsafe.Pointer(&threadId)),
+		0,
+		0)
+	runtime.KeepAlive(sa)
+	if int(r1) == 0 {
+		return syscall.InvalidHandle, 0, getSyscallErr(e1)
+	}
+	return syscall.Handle(r1), threadId, nil
+}
+
+func _writeProcessMemory(handle syscall.Handle, baseAddress uintptr, buffer uintptr, size uintptr, numWritten *uintptr) (err error) {
+	r1, _, e1 := syscall.Syscall6(procWriteProcessMemory.Addr(), 5, uintptr(handle), uintptr(baseAddress), uintptr(buffer), uintptr(size), uintptr(unsafe.Pointer(numWritten)), 0)
+	if r1 == 0 {
+		err = getSyscallErr(e1)
+	}
+	return
+}
+
+func _virtualAllocEx(processHandle syscall.Handle, address uintptr, size uintptr, allocType uint32, protect uint32) (baseAddr uintptr, err error) {
+	r1, _, e1 := syscall.Syscall6(procVirtualAllocEx.Addr(), 5, uintptr(processHandle), uintptr(address), uintptr(size),
+		uintptr(allocType), uintptr(protect), 0)
+	if r1 == 0 {
+		err = getSyscallErr(e1)
+	}
+	return r1, err
+}
+
+func _virtualFreeEx(processHandle syscall.Handle, address uintptr, size uintptr, freeType uint32) (err error) {
+	r1, _, e1 := syscall.Syscall6(procVirtualFreeEx.Addr(), 4, uintptr(processHandle), uintptr(address), uintptr(size),
+		uintptr(freeType), 0, 0)
+	if r1 == 0 {
+		err = getSyscallErr(e1)
+	}
+	return err
+}
+
+func _virtualQueryEx(processHandle syscall.Handle, address uintptr, buffer uintptr, size uintptr, nRead *uintptr) (err error) {
+	r1, _, e1 := syscall.Syscall6(procVirtualQueryEx.Addr(), 4, uintptr(processHandle), uintptr(address), uintptr(buffer), uintptr(size),
 		0, 0)
 	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
+		err = getSyscallErr(e1)
 	}
 	*nRead = r1
 	return err
 }
 
-func VirtualQueryEx(handle syscall.Handle, baseAddress uintptr, dest []byte) (nRead uintptr, err error) {
+func virtualQueryEx(processHandle syscall.Handle, baseAddress uintptr, dest []byte) (nRead uintptr, err error) {
 	n := len(dest)
 	if n == 0 {
 		return 0, nil
 	}
-	if err = _VirtualQueryEx(handle, baseAddress, uintptr(unsafe.Pointer(&dest[0])), uintptr(n), &nRead); err != nil {
+	if err = _virtualQueryEx(processHandle, baseAddress, uintptr(unsafe.Pointer(&dest[0])), uintptr(n), &nRead); err != nil {
 		return 0, err
 	}
 	return nRead, nil
 }
 
-func getProcessEnv(handle syscall.Handle, params RtlUserProcessParameters) (env string, err error) {
+func getProcessEnv(processHandle syscall.Handle, params RtlUserProcessParameters) (env string, err error) {
 	// get the size of the env variables block
 	mbiBuf := make([]byte, SizeOfMemoryBasicInformation)
-	nRead, err := VirtualQueryEx(handle, params.Environment, mbiBuf)
+	nRead, err := virtualQueryEx(processHandle, params.Environment, mbiBuf)
 	if err != nil {
 		return env, err
 	}
@@ -226,7 +432,7 @@ func getProcessEnv(handle syscall.Handle, params RtlUserProcessParameters) (env 
 	envSize := mbi.RegionSize - (uintptr(params.Environment) - uintptr(mbi.BaseAddress))
 
 	envBuf := make([]byte, envSize)
-	nRead, err = windows.ReadProcessMemory(handle, params.Environment, envBuf)
+	nRead, err = windows.ReadProcessMemory(processHandle, params.Environment, envBuf)
 	if err != nil {
 		return env, err
 	}
@@ -234,7 +440,7 @@ func getProcessEnv(handle syscall.Handle, params RtlUserProcessParameters) (env 
 		return env, errors.Errorf("Environment string: short read: (%d/%d)", nRead, envSize)
 	}
 
-	env, err = UTF16BytesToString(envBuf)
+	env, err = utf16BytesToString(envBuf)
 	if err != nil {
 		return env, err
 	}
@@ -242,37 +448,505 @@ func getProcessEnv(handle syscall.Handle, params RtlUserProcessParameters) (env 
 	return env, nil
 }
 
-func getChildMarkerKey() string {
-	return "RUSH_CHILD_GROUP"
+func getShell() (shell string) {
+	shell = os.Getenv("COMSPEC")
+	if shell == "" {
+		shell = "C:\\WINDOWS\\System32\\cmd.exe"
+	}
+	return shell
 }
 
-func getChildMarkerValue() string {
-	// place brackets on either side of pid integer,
-	// so we only find exact matches
-	return fmt.Sprintf("[%d]", os.Getpid())
+func getCommand(ctx context.Context, qcmd string) (command *exec.Cmd) {
+	if ctx != nil {
+		command = exec.CommandContext(ctx, getShell())
+	} else {
+		command = exec.Command(getShell())
+	}
+	// from https://github.com/junegunn/fzf/blob/390b49653b441c958b82a0f78d9923aef4c1d9a2/src/util/util_windows.go
+	command.SysProcAttr = &syscall.SysProcAttr{
+		HideWindow:    false,
+		CmdLine:       fmt.Sprintf(` /s /c "%s"`, qcmd),
+		CreationFlags: 0,
+	}
+	return command
 }
 
-func getChildMarkerRegex() *regexp.Regexp {
-	// match string with one or more [pid] values
-	return regexp.MustCompile(getChildMarkerKey() + "=[\\[\\d+\\]]+")
+func considerPid(pid int) bool {
+	// skip our process, the System process, and the Idle process
+	return pid != os.Getpid() &&
+		pid != 0 &&
+		pid != 4
 }
 
-func doesChildHaveMarker(handle syscall.Handle) (childHasMarker bool, err error) {
-	childHasMarker = false
-	pbi, err := getProcessBasicInformation(handle)
+func getSignalsToSend(childProcessName string, noStopExes []string, noKillExes []string) (signalsToSend int, err error) {
+	signalsToSend = SEND_NO_SIGNAL // first assume no signal
+	canSendStopSignal, err := canSendSignal(childProcessName, noStopExes)
 	if err == nil {
-		userProcParams, err := getUserProcessParams(handle, pbi)
+		if canSendStopSignal {
+			signalsToSend |= SEND_CTRL_C_SIGNAL
+			signalsToSend |= SEND_CTRL_BREAK_SIGNAL
+		}
+		canSendKillSignal, err := canSendSignal(childProcessName, noKillExes)
 		if err == nil {
-			env, err := getProcessEnv(handle, userProcParams)
-			if err == nil {
-				childMarkerRegex := getChildMarkerRegex()
-				childMarkerValue := getChildMarkerValue()
-				match := childMarkerRegex.FindString(env)
-				childHasMarker = strings.Contains(match, childMarkerValue)
+			if canSendKillSignal {
+				signalsToSend |= SEND_KILL_SIGNAL
 			}
 		}
 	}
-	return childHasMarker, err
+	return signalsToSend, err
+}
+
+func doesChildHaveMarker(processHandle int) (hasMarker bool, err error) {
+	err = nil
+	hasMarker = false
+	winProcessHandle := syscall.Handle(processHandle)
+	pbi, err := getProcessBasicInformation(winProcessHandle)
+	if err == nil {
+		userProcParams, err := getUserProcessParams(winProcessHandle, pbi)
+		if err == nil {
+			env, err := getProcessEnv(winProcessHandle, userProcParams)
+			if err == nil {
+				hasMarker = containsMarker(env)
+			}
+		}
+	}
+	return hasMarker, err
+}
+
+func is64BitWindowsOS() bool {
+	var wow64Dir [256]byte
+	err1 := getSystemWow64DirectoryW(
+		uintptr(unsafe.Pointer(&wow64Dir[0])),
+		uintptr(len(wow64Dir)))
+	return err1 == nil // no error means 64-bit Windows OS
+}
+
+/* C:\temp\shellcode\signalExe32.exe (9/20/2018 12:42:19 PM)
+   StartOffset(h): 00000200, EndOffset(h): 000002B7, Length(h): 000000B8 */
+
+var signalExe32 = []byte{
+	0x83, 0xEC, 0x04, 0x56, 0x31, 0xC0, 0x31, 0xDB, 0xB3, 0x30, 0x64, 0x8B,
+	0x03, 0x8B, 0x40, 0x0C, 0x8B, 0x40, 0x14, 0x50, 0x5E, 0x8B, 0x06, 0x50,
+	0x5E, 0x8B, 0x06, 0x8B, 0x40, 0x10, 0x5E, 0xEB, 0x70, 0x60, 0x8B, 0x6C,
+	0x24, 0x24, 0x8B, 0x45, 0x3C, 0x8B, 0x54, 0x05, 0x78, 0x01, 0xEA, 0x8B,
+	0x4A, 0x18, 0x8B, 0x5A, 0x20, 0x01, 0xEB, 0xE3, 0x34, 0x49, 0x8B, 0x34,
+	0x8B, 0x01, 0xEE, 0x31, 0xFF, 0x31, 0xC0, 0xFC, 0xAC, 0x84, 0xC0, 0x74,
+	0x07, 0xC1, 0xCF, 0x0D, 0x01, 0xC7, 0xEB, 0xF4, 0x3B, 0x7C, 0x24, 0x28,
+	0x75, 0xE1, 0x8B, 0x5A, 0x24, 0x01, 0xEB, 0x66, 0x8B, 0x0C, 0x4B, 0x8B,
+	0x5A, 0x1C, 0x01, 0xEB, 0x8B, 0x04, 0x8B, 0x01, 0xE8, 0x89, 0x44, 0x24,
+	0x1C, 0x61, 0xC3, 0xAD, 0x50, 0x52, 0xE8, 0xAA, 0xFF, 0xFF, 0xFF, 0x89,
+	0x07, 0x83, 0xC4, 0x08, 0x83, 0xC7, 0x04, 0x39, 0xCE, 0x75, 0xEC, 0xC3,
+	0xE8, 0x11, 0x00, 0x00, 0x00, 0x8E, 0x4E, 0x0E, 0xEC, 0xF9, 0x4C, 0xDC,
+	0x3D, 0x83, 0xEC, 0x08, 0x89, 0xE5, 0x89, 0xC2, 0xEB, 0xEA, 0x5E, 0x8D,
+	0x7D, 0x04, 0x89, 0xF1, 0x83, 0xC1, 0x08, 0xE8, 0xC7, 0xFF, 0xFF, 0xFF,
+	0x6A, 0x00, 0x8B, 0x5C, 0x24, 0x14, 0x53, 0xFF, 0x55, 0x08, 0x31, 0xC0,
+	0x83, 0xC4, 0x08, 0xC3}
+
+/*
+; from https://gist.github.com/debasishm89/5746556 with mods
+; to call GenerateConsoleCtrlEvent
+[Section .text]
+[BITS 32]
+
+start:
+;===========FUNCTIONS=============
+;=======Function : Get Kernel32 base address============
+;Technique : PEB InMemoryOrderModuleList
+sub esp, 0x4             ; reserve stack space for called functions
+push esi
+xor eax, eax             ; clear eax
+xor ebx, ebx
+mov bl,0x30
+mov eax, [fs:ebx ]      ; get a pointer to the PEB
+mov eax, [ eax + 0x0C ]  ; get PEB->Ldr
+mov eax, [ eax + 0x14 ]  ; get PEB->Ldr.InMemoryOrderModuleList.Flink (1st entry)
+push eax
+pop esi
+mov eax, [ esi ]         ; get the next entry (2nd entry)
+push eax
+pop esi
+mov eax, [ esi ]         ; get the next entry (3rd entry)
+mov eax, [ eax + 0x10 ]  ; get the 3rd entries base address (kernel32.dll)
+pop esi
+
+jmp start_main
+
+;=======Function : Find function base address============
+find_function:
+pushad                           ;save all registers
+mov ebp,  [esp  +  0x24]         ;put base address of module that is being
+								 ;loaded in ebp
+mov eax,  [ebp  +  0x3c]         ;skip over MSDOS header
+mov edx,  [ebp  +  eax  +  0x78] ;go to export table and put relative address
+								 ;in edx
+add edx,  ebp                    ;add base address to it.
+								 ;edx = absolute address of export table
+mov ecx,  [edx  +  0x18]         ;set up counter ECX
+								 ;(how many exported items are in array ?)
+mov ebx,  [edx  +  0x20]         ;put names table relative offset in ebx
+add ebx,  ebp                    ;add base address to it.
+								 ;ebx = absolute address of names table
+
+find_function_loop:
+jecxz  find_function_finished    ;if ecx=0, then last symbol has been checked.
+								 ;(should never happen)
+								 ;unless function could not be found
+dec ecx                          ;ecx=ecx-1
+mov esi,  [ebx  +  ecx  *  4]    ;get relative offset of the name associated
+								 ;with the current symbol
+								 ;and store offset in esi
+add esi,  ebp                    ;add base address.
+								 ;esi = absolute address of current symbol
+
+compute_hash:
+xor edi,  edi                    ;zero out edi
+xor eax,  eax                    ;zero out eax
+cld                              ;clear direction flag.
+								 ;will make sure that it increments instead of
+								 ;decrements when using lods*
+
+compute_hash_again:
+lodsb                            ;load bytes at esi (current symbol name)
+								 ;into al, + increment esi
+test al,  al                      ;bitwise test :
+								 ;see if end of string has been reached
+jz  compute_hash_finished        ;if zero flag is set = end of string reached
+ror edi,  0xd                    ;if zero flag is not set, rotate current
+								 ;value of hash 13 bits to the right
+add edi,  eax                    ;add current character of symbol name
+								 ;to hash accumulator
+jmp compute_hash_again           ;continue loop
+
+compute_hash_finished:
+
+find_function_compare:
+cmp edi,  [esp  +  0x28]         ;see if computed hash matches requested hash (at esp+0x28)
+								 ;edi = current computed hash
+								 ;esi = current function name (string)
+jnz find_function_loop           ;no match, go to next symbol
+mov ebx,  [edx  +  0x24]         ;if match : extract ordinals table
+								 ;relative offset and put in ebx
+add ebx,  ebp                    ;add base address.
+								 ;ebx = absolute address of ordinals address table
+mov cx,  [ebx  +  2  *  ecx]     ;get current symbol ordinal number (2 bytes)
+mov ebx,  [edx  +  0x1c]         ;get address table relative and put in ebx
+add ebx,  ebp                    ;add base address.
+								 ;ebx = absolute address of address table
+mov eax,  [ebx  +  4  *  ecx]    ;get relative function offset from its ordinal and put in eax
+add eax,  ebp                    ;add base address.
+								 ;eax = absolute address of function address
+mov [esp  +  0x1c],  eax         ;overwrite stack copy of eax so popad
+								 ;will return function address in eax
+find_function_finished:
+popad                           ;retrieve original registers.
+								;eax will contain function address
+ret
+
+;=======Function : loop to lookup functions for a given dll (process all hashes)============
+find_funcs_for_dll:
+	lodsd                   ;load current hash into eax (pointed to by esi)
+	push eax                ;push hash to stack
+	push edx                ;push base address of dll to stack
+	call find_function
+	mov [edi], eax          ;write function pointer into address at edi
+	add esp, 0x08
+	add edi, 0x04           ;increase edi to store next pointer
+	cmp esi, ecx            ;did we process all hashes yet ?
+	jne find_funcs_for_dll  ;get next hash and lookup function pointer
+find_funcs_for_dll_finished:
+	ret
+
+;=======Function : Get pointers to function hashes============
+
+GetHashes:
+	call GetHashesReturn
+  ;LoadLibraryA               hash 0xec0e4e8e number from rot13.exe
+	db 0x8E
+	db 0x4E
+	db 0x0E
+	db 0xEC
+
+  ;GenerateConsoleCtrlEvent   hash 0x3ddc4cf9 number from rot13.exe
+	db 0xF9
+	db 0x4C
+	db 0xDC
+	db 0x3D
+
+;====================================================================
+;=================== MAIN APPLICATION ===============================
+;====================================================================
+
+start_main:
+	sub esp,0x08         ;allocate space on stack to store 2 things :
+						 ;in this order : ptr to LoadLibraryA, GenerateConsoleCtrlEvent
+	mov ebp,esp          ;set ebp as frame ptr for relative offset
+						 ;so we will be able to do this:
+						 ;call ebp+4   = Execute LoadLibraryA
+						 ;call ebp+8   = Execute GenerateConsoleCtrlEvent
+	mov edx,eax      ;save base address of kernel32 in edx
+;locate    functions inside kernel32 first
+	jmp GetHashes    ;get address of first hash
+GetHashesReturn:
+	pop esi              ;get pointer to hash into esi
+	lea edi, [ebp+0x4]   ;we will store the function addresses at edi
+						 ; (edi will be increased with 0x04 for each hash)
+						 ; (see resolve_symbols_for_dll)
+	mov ecx,esi
+	add ecx,0x08          ; store address of last hash into ecx
+	call find_funcs_for_dll   ; get function pointers for the 2
+							  ; kernel32 function hashes
+						  ; and put them at ebp+4 and ebp+8
+
+;GenerateConsoleCtrlEvent
+	push 0               ; ProcessGroupId 0
+	mov ebx, [esp+0x14]  ; get parameter from ThreadProc
+	push ebx             ; CtrlEvent
+	call [ebp+8]         ; GenerateConsoleCtrlEvent
+
+	xor eax,eax          ; return 0 thread exit code (success)
+	add esp, 0x8
+	ret
+*/
+
+/* C:\temp\shellcode\signalExe64.exe (9/26/2018 10:17:38 AM)
+   StartOffset(h): 00000200, EndOffset(h): 000002BA, Length(h): 000000BB */
+
+var signalExe64 = []byte{
+	0x49, 0x89, 0xC8, 0x48, 0x83, 0xEC, 0x28, 0x48, 0x83, 0xE4, 0xF0, 0x65,
+	0x4C, 0x8B, 0x24, 0x25, 0x60, 0x00, 0x00, 0x00, 0x4D, 0x8B, 0x64, 0x24,
+	0x18, 0x4D, 0x8B, 0x64, 0x24, 0x20, 0x4D, 0x8B, 0x24, 0x24, 0x4D, 0x8B,
+	0x24, 0x24, 0x4D, 0x8B, 0x64, 0x24, 0x20, 0xBA, 0xF9, 0x4C, 0xDC, 0x3D,
+	0x4C, 0x89, 0xE1, 0xE8, 0x11, 0x00, 0x00, 0x00, 0x48, 0x89, 0xC3, 0x31,
+	0xD2, 0x44, 0x89, 0xC1, 0xFF, 0xD3, 0x31, 0xC0, 0x48, 0x83, 0xC4, 0x28,
+	0xC3, 0x49, 0x89, 0xCD, 0x49, 0x0F, 0xB7, 0x45, 0x3C, 0x4D, 0x31, 0xF6,
+	0x45, 0x8B, 0xB4, 0x05, 0x88, 0x00, 0x00, 0x00, 0x4D, 0x01, 0xEE, 0x4D,
+	0x31, 0xD2, 0x45, 0x8B, 0x56, 0x18, 0x48, 0x31, 0xDB, 0x41, 0x8B, 0x5E,
+	0x20, 0x4C, 0x01, 0xEB, 0x67, 0xE3, 0x47, 0x41, 0xFF, 0xCA, 0x48, 0x31,
+	0xF6, 0x42, 0x8B, 0x34, 0x93, 0x4C, 0x01, 0xEE, 0x31, 0xFF, 0x31, 0xC0,
+	0xFC, 0xAC, 0x84, 0xC0, 0x74, 0x07, 0xC1, 0xCF, 0x0D, 0x01, 0xC7, 0xEB,
+	0xF4, 0x39, 0xD7, 0x75, 0xDB, 0x48, 0x31, 0xDB, 0x41, 0x8B, 0x5E, 0x24,
+	0x4C, 0x01, 0xEB, 0x48, 0x31, 0xC9, 0x66, 0x42, 0x8B, 0x0C, 0x53, 0x48,
+	0x31, 0xDB, 0x41, 0x8B, 0x5E, 0x1C, 0x4C, 0x01, 0xEB, 0x48, 0x31, 0xC0,
+	0x8B, 0x04, 0x8B, 0x4C, 0x01, 0xE8, 0xC3}
+
+/*
+; from https://www.tophertimzen.com/blog/windowsx64Shellcode/ with mods
+; to call GenerateConsoleCtrlEvent
+bits 64
+section .text
+global start
+
+start:
+;get dll base addresses
+	mov r8, rcx                  ;parameter from ThreadProc
+	sub rsp, 28h                 ;reserve stack space for called functions
+	and rsp, 0fffffffffffffff0h  ;make sure stack 16-byte aligned
+
+	mov r12, [gs:60h]            ;peb
+	mov r12, [r12 + 0x18]        ;Peb --> LDR
+	mov r12, [r12 + 0x20]        ;Peb.Ldr.InMemoryOrderModuleList
+	mov r12, [r12]               ;2st entry
+	;[r12 + 0x20]                ;ntdll.dll base address!
+	mov r12, [r12]               ;3nd entry
+	mov r12, [r12 + 0x20]        ;kernel32.dll base address!
+
+;get GenerateConsoleCtrlEvent address
+	mov rdx, 0x3ddc4cf9          ;number from rot13.exe
+	mov rcx, r12                 ;kernel32.dll
+	call GetProcessAddress
+	mov rbx, rax
+
+;call GenerateConsoleCtrlEvent
+	xor edx, edx                 ;ProcessGroupId 0
+	mov ecx, r8d                 ;CtrlEvent (parameter from ThreadProc)
+	call rbx
+
+	xor eax, eax                 ;return 0 thread exit code (success)
+	add rsp, 28h
+	ret
+
+;Hashing section to resolve a function address
+GetProcessAddress:
+	mov r13, rcx                   ;base address of dll loaded
+	movzx rax, word [r13 + 0x3c]   ;skip DOS header and go to PE header
+	xor r14, r14                   ;zero out r14
+	mov r14d, [r13 + rax + 0x88]   ;0x88 offset from the PE header is the export table.
+
+	add r14, r13                   ;make the export table an absolute base address and put it in r14.
+	xor r10, r10                   ;zero out r10
+	mov r10d, [r14 + 0x18]         ;go into the export table and get the numberOfNames
+	xor rbx, rbx                   ;zero out rbx
+	mov ebx, [r14 + 0x20]          ;get the AddressOfNames offset.
+	add rbx, r13                   ;AddressofNames base.
+
+find_function_loop:
+	jecxz find_function_finished   ;if ecx is zero, quit :( nothing found.
+	dec r10d                       ;dec ECX by one for the loop until a match/none are found
+	xor rsi, rsi                   ;zero out rsi
+	mov esi, [rbx + r10 * 4]       ;get a name to play with from the export table.
+	add rsi, r13                   ;rsi is now the current name to search on.
+
+find_hashes:
+	xor edi, edi
+	xor eax, eax
+	cld
+
+continue_hashing:
+	lodsb                         ;get into al from rsi
+	test al, al                   ;is the end of string resarched?
+	jz compute_hash_finished
+	ror dword edi, 0xd            ;ROR13 for hash calculation!
+	add edi, eax
+	jmp continue_hashing
+
+compute_hash_finished:
+	cmp edi, edx                  ;edx has the function hash
+	jnz find_function_loop        ;didn't match, keep trying!
+	xor rbx, rbx                  ;zero out rbx
+	mov ebx, [r14 + 0x24]         ;put the address of the ordinal table and put it in ebx.
+	add rbx, r13                  ;absolute address
+	xor rcx, rcx                  ;zero out rcx
+	mov cx, [rbx + 2 * r10]       ;ordinal = 2 bytes. Get the current ordinal and put it in cx. ECX was our counter for which # we were in.
+	xor rbx, rbx                  ;zero out rbx
+	mov ebx, [r14 + 0x1c]         ;extract the address table offset
+	add rbx, r13                  ;put absolute address in rbx.
+	xor rax, rax                  ;zero out rax
+	mov eax, [rbx + 4 * rcx]      ;relative address
+	add rax, r13
+
+find_function_finished:
+	ret
+*/
+
+func _signalProcess(processRecord ProcessRecord, signalNum int) (err error) {
+	var winCtrlEvent int = 0
+	switch signalNum {
+	case CTRL_C_SIGNAL:
+		winCtrlEvent = 0 // Windows CTRL_C_EVENT
+	case CTRL_BREAK_SIGNAL:
+		winCtrlEvent = 1 // Windows CTRL_BREAK_EVENT
+	case KILL_SIGNAL:
+		err = errors.New("Unexpected signalNum KILL_SIGNAL")
+	default:
+		err = errors.New("Unexpected signalNum")
+	}
+
+	var is32BitChildProcess bool = true
+	if is64BitWindowsOS() {
+		is32BitChildProcess, err = isWow64Process(syscall.Handle(processRecord.processHandle))
+		if err != nil {
+			if Verbose {
+				Log.Error(err)
+			}
+		}
+	}
+
+	var signalExe []byte
+	if is32BitChildProcess {
+		signalExe = signalExe32
+	} else {
+		signalExe = signalExe64
+	}
+
+	signalExeLength := len(signalExe)
+	var nWritten uintptr = 0
+	remoteBaseAddr, err := _virtualAllocEx(
+		syscall.Handle(processRecord.processHandle),
+		0,
+		uintptr(signalExeLength),
+		uint32(MEM_COMMIT|MEM_RESERVE),
+		uint32(PAGE_EXECUTE_READWRITE))
+	if err == nil {
+		err = _writeProcessMemory(
+			syscall.Handle(processRecord.processHandle),
+			remoteBaseAddr,
+			uintptr(unsafe.Pointer(&signalExe[0])),
+			uintptr(signalExeLength),
+			&nWritten)
+		if err != nil {
+			if Verbose {
+				if !isAccessDeniedError(err) {
+					Log.Error(err)
+				}
+			}
+		}
+	} else {
+		if Verbose {
+			if !isAccessDeniedError(err) {
+				Log.Error(err)
+			}
+		}
+	}
+
+	var threadHandle syscall.Handle = 0
+	if err == nil {
+		if nWritten == uintptr(signalExeLength) {
+			threadHandle, _, err = _createRemoteThread(
+				syscall.Handle(processRecord.processHandle), nil, 0, remoteBaseAddr, uintptr(winCtrlEvent), 0)
+		} else {
+			err = errors.Errorf("ThreadProc: short write (%d/%d)", nWritten, signalExeLength)
+		}
+	}
+
+	if err == nil {
+		if int(threadHandle) != 0 && int(threadHandle) != INVALID_HANDLE {
+			if Verbose {
+				msg := "sent "
+				switch signalNum {
+				case CTRL_C_SIGNAL:
+					msg += "Ctrl+C"
+				case CTRL_BREAK_SIGNAL:
+					msg += "Ctrl+Break"
+				case KILL_SIGNAL:
+					err = errors.New("Unexpected signalNum KILL_SIGNAL")
+				default:
+					err = errors.New("Unexpected signalNum")
+				}
+				Log.Infof("%s to pid %s, waiting for response", msg, strconv.Itoa(processRecord.pid))
+			}
+			var event uint32
+			event, err = waitForSingleObject(threadHandle, syscall.INFINITE)
+			switch event {
+			case syscall.WAIT_OBJECT_0:
+				break
+			case syscall.WAIT_FAILED:
+				err = errors.New("Wait failed WaitForSingleObject")
+			default:
+				err = errors.New("Unexpected result from WaitForSingleObject")
+			}
+		} else {
+			err = errors.New("Invalid thread handle from CreateRemoteThread")
+		}
+		if err != nil {
+			if Verbose {
+				if !isAccessDeniedError(err) {
+					Log.Error(err)
+				}
+			}
+		}
+	} else {
+		if Verbose {
+			if !isAccessDeniedError(err) {
+				Log.Error(err)
+			}
+		}
+	}
+
+	// ignore errors from CloseHandle, since process may have gone away
+	syscall.CloseHandle(threadHandle)
+
+	// ignore errors from free, since process may have gone away
+	_virtualFreeEx(
+		syscall.Handle(processRecord.processHandle),
+		remoteBaseAddr,
+		0,
+		uint32(MEM_RELEASE))
+
+	// ignore access denied error, since process may have gone away
+	if isAccessDeniedError(err) {
+		err = nil
+	}
+	return err
 }
 
 const (
@@ -280,207 +954,43 @@ const (
 	STILL_ACTIVE = 259
 )
 
-func killWindowsChildProcess(handle syscall.Handle, pid int) (err error) {
-	var state uint32
-	err = syscall.GetExitCodeProcess(handle, &state)
-	if err == nil {
-		if state == STILL_ACTIVE { // process still exists
-			attempts := 1
-			for {
-				if Verbose {
-					Log.Infof("taskkill /t /f /pid %s", strconv.Itoa(pid))
-				}
-
-				out, err := exec.Command("taskkill", "/t", "/f", "/pid", strconv.Itoa(pid)).Output()
-
-				if Verbose {
-					if err != nil {
-						Log.Error(err)
-					}
-					Log.Infof("%s", out)
-				}
-
-				err = syscall.GetExitCodeProcess(handle, &state)
-				if err == nil {
-					if state != STILL_ACTIVE { // process no longer exists
-						break
-					}
-				} else {
-					if Verbose {
-						Log.Error(err)
-					}
-				}
-				time.Sleep(10 * time.Millisecond)
-				attempts += 1
-				if attempts > 30 {
-					// timed out
-					timeoutMsg := fmt.Sprintf("Timed out trying to kill child process, pid %d", pid)
-					err = errors.New(timeoutMsg)
-					break
-				}
-			}
-		}
-	} else {
-		if Verbose {
+func killProcess(processRecord ProcessRecord) (err error) {
+	pidStr := strconv.Itoa(processRecord.pid)
+	if Verbose {
+		Log.Infof("taskkill /t /f /pid %s", pidStr)
+	}
+	out, err := exec.Command("taskkill", "/t", "/f", "/pid", pidStr).Output()
+	if Verbose {
+		if err != nil {
 			Log.Error(err)
 		}
+		Log.Infof("%s", out)
 	}
 	return err
 }
 
-func checkWindowsChildProcess(childProcess *psutil.Process) (handle syscall.Handle, considerChild bool, err error) {
-	// ignore errors from openProcess, since child may no longer exist
-	var err2 error
-	handle, err2 = openProcess(int(childProcess.Pid))
-	if err2 == nil {
-		if handle != syscall.InvalidHandle {
-			considerChild, err = doesChildHaveMarker(handle)
-		} else {
-			// failed to open child process, so don't consider it
-			considerChild = false
-		}
-	} else {
-		// child no longer exists, so don't consider it
-		considerChild = false
+func signalProcess(processRecord ProcessRecord, signalNum int) (err error) {
+	switch signalNum {
+	case CTRL_C_SIGNAL, CTRL_BREAK_SIGNAL:
+		err = _signalProcess(processRecord, signalNum)
+	case KILL_SIGNAL:
+		err = pollKillProcess(processRecord)
+	default:
+		err = errors.New("Unexpected signalNum")
 	}
-	return handle, considerChild, err
+	return err
 }
 
-// from https://softwareengineering.stackexchange.com/questions/177428/sets-data-structure-in-golang
-type IntSet struct {
-	set map[int]bool
-}
-
-func (set *IntSet) Add(i int) bool {
-	_, found := set.set[i]
-	set.set[i] = true
-	return !found //False if it existed already
-}
-
-// stop process tree in bottom up order
-func killWindowsProcessTreeRecursive(
-	childProcess *psutil.Process,
-	checkBeforeDescending bool,
-	pidsVisited *IntSet,
-) (childrenWereStopped bool) {
-	childrenWereStopped = true // first assume true
-	// skip our process, the System process, and the Idle process
-	if childProcess.Pid != int32(os.Getpid()) &&
-		childProcess.Pid != 0 &&
-		childProcess.Pid != 4 {
-		// avoid cycles in pid tree by looking at visited set
-		if pidsVisited.Add(int(childProcess.Pid)) {
-			handle := syscall.InvalidHandle
-			considerChild := true // first assume true
-			var err error
-			if checkBeforeDescending {
-				handle, considerChild, err = checkWindowsChildProcess(childProcess)
-				if err != nil {
-					childrenWereStopped = false
-					if Verbose {
-						Log.Error(err)
-					}
-				}
-			}
-			if considerChild {
-				grandChildren, err := childProcess.Children()
-				if err == nil {
-					if grandChildren != nil {
-						for _, grandChildProcess := range grandChildren {
-							childrenWereStopped = childrenWereStopped && killWindowsProcessTreeRecursive(
-								grandChildProcess,
-								checkBeforeDescending,
-								pidsVisited)
-						}
-					}
-				} else {
-					childrenWereStopped = false
-					if Verbose {
-						Log.Error(err)
-					}
-				}
-				// only kill child process if we were able to kill its children
-				if childrenWereStopped {
-					if !checkBeforeDescending {
-						handle, considerChild, err = checkWindowsChildProcess(childProcess)
-						if err != nil {
-							childrenWereStopped = false
-							if Verbose {
-								Log.Error(err)
-							}
-						}
-					}
-					if considerChild {
-						if handle != syscall.InvalidHandle {
-							err = killWindowsChildProcess(handle, int(childProcess.Pid))
-							if err != nil {
-								childrenWereStopped = false
-								if Verbose {
-									Log.Error(err)
-								}
-							}
-						}
-					}
-				}
-			}
-			if handle != syscall.InvalidHandle {
-				syscall.CloseHandle(handle)
-			}
-		}
-	}
-	return childrenWereStopped
-}
-
-// ensure our child processes go away
-func KillWindowsChildProcesses() (childrenWereStopped bool) {
-	// stop any child processes that were spawned from our env
-	childrenWereStopped = true // first assume true
-	processes, err := psutil.Processes()
-	if err == nil {
-		if processes != nil {
-			pidsVisited := IntSet{set: make(map[int]bool)}
-			for _, process := range processes {
-				// specify checkBeforeDescending true here,
-				// since only want to descend if process is one of our children
-				childrenWereStopped = childrenWereStopped && killWindowsProcessTreeRecursive(
-					process,
-					true, // checkBeforeDescending
-					&pidsVisited)
-			}
-		}
+func canStopChildProcesses() bool {
+	// some prerequisites prevent us from trying to stop the child processes
+	// if so, print error to the user
+	if is32bitRush && is64BitWindowsOS() {
+		msg := "The win32 rush cannot signal 64-bit Windows child processes\n"
+		msg += "       " // seven spaces indent
+		msg += "Please use the win64 rush on 64-bit Windows"
+		Log.Error(msg)
+		return false
 	} else {
-		childrenWereStopped = false
-		if Verbose {
-			Log.Error(err)
-		}
-	}
-
-	return childrenWereStopped
-}
-
-// from https://github.com/junegunn/fzf/blob/390b49653b441c958b82a0f78d9923aef4c1d9a2/src/util/util_windows.go
-func (c *Command) setWindowsCommandFields(command *exec.Cmd, qcmd string) {
-	if isWindows {
-		command.SysProcAttr = &syscall.SysProcAttr{
-			HideWindow:    false,
-			CmdLine:       fmt.Sprintf(` /s /c "%s"`, qcmd),
-			CreationFlags: 0,
-		}
-		// mark child processes with our pid,
-		// so we can identify them later,
-		// in case we need to kill them
-		childMarkerKey := getChildMarkerKey()
-		childMarkerValue := getChildMarkerValue()
-		priorValue, found := os.LookupEnv(childMarkerKey)
-		if found {
-			// append marker values to sames key, so
-			// we can handle the nested calls case
-			childMarkerValue = priorValue + childMarkerValue
-		}
-		childMarker := fmt.Sprintf("%s=%s", childMarkerKey, childMarkerValue)
-		// command de-dups variables, in favor of later values
-		command.Env = append(os.Environ(), childMarker)
-	} else {
-		panic("should have called process_others.go setWindowsCommandFields()!")
+		return true
 	}
 }

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -1,0 +1,36 @@
+// Copyright © 2017 Wei Shen <shenwei356@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package process
+
+import (
+	"fmt"
+	"os/exec"
+	"syscall"
+)
+
+// from https://github.com/junegunn/fzf/blob/390b49653b441c958b82a0f78d9923aef4c1d9a2/src/util/util_windows.go
+func (c *Command) setWindowsCommandAttr(command *exec.Cmd, qcmd string) {
+	command.SysProcAttr = &syscall.SysProcAttr{
+		HideWindow:    false,
+		CmdLine:       fmt.Sprintf(` /s /c "%s"`, qcmd),
+		CreationFlags: 0,
+	}
+}

--- a/root.go
+++ b/root.go
@@ -31,8 +31,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/bburgin/rush/process"
+	"github.com/pkg/errors"
 	"github.com/shenwei356/util/stringutil"
 	"github.com/shenwei356/xopen"
 	"github.com/spf13/cobra"
@@ -276,7 +276,7 @@ Homepage: https://github.com/shenwei356/rush
 		// ---------------------------------------------------------------
 
 		// run
-		chOutput, chSuccessfulCmd, doneSendOutput, chExitStatus  := process.Run4Output(opts, cancel, chCmdStr)
+		chOutput, chSuccessfulCmd, doneSendOutput, chExitStatus := process.Run4Output(opts, cancel, chCmdStr)
 
 		// read from chOutput and print
 		doneOutput := make(chan int)
@@ -357,7 +357,7 @@ Homepage: https://github.com/shenwei356/rush
 			}
 		}()
 
-			// the order is very important!
+		// the order is very important!
 		<-donePreprocessFiles // finish read data and send command
 		<-doneSendOutput      // finish send output
 		<-doneOutput          // finish print output
@@ -530,16 +530,16 @@ type Config struct {
 	FieldDelimiter       string
 	reFieldDelimiter     *regexp.Regexp
 
-	Retries       int
-	RetryInterval int
+	Retries          int
+	RetryInterval    int
 	PrintRetryOutput bool
-	Timeout       int
+	Timeout          int
 
-	KeepOrder bool
-	StopOnErr bool
+	KeepOrder      bool
+	StopOnErr      bool
 	PropExitStatus bool
-	KillOnCtrlC bool
-	DryRun     bool
+	KillOnCtrlC    bool
+	DryRun         bool
 
 	Continue    bool
 	SuccCmdFile string

--- a/root.go
+++ b/root.go
@@ -38,6 +38,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var isWindows bool = runtime.GOOS == "windows"
+
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use:   "rush",
@@ -355,6 +357,15 @@ Homepage: https://github.com/shenwei356/rush
 				case <-cancel: // already closed
 				default:
 					close(cancel)
+				}
+				if opts.KillOnCtrlC {
+					if isWindows {
+						// kill any child processes
+						childrenWereStopped := process.KillWindowsChildProcesses()
+						if !childrenWereStopped {
+							checkError(fmt.Errorf("could not stop children"))
+						}
+					}
 				}
 				cleanupDone <- 1
 				return

--- a/root.go
+++ b/root.go
@@ -134,6 +134,8 @@ Homepage: https://github.com/shenwei356/rush
 			KeepOrder:           config.KeepOrder,
 			Retries:             config.Retries,
 			RetryInterval:       time.Duration(config.RetryInterval) * time.Second,
+			OutFileHandle:       outfh,
+			ErrFileHandle:       errfh,
 			ImmediateOutput:     config.ImmediateOutput,
 			PrintRetryOutput:    config.PrintRetryOutput,
 			Timeout:             time.Duration(config.Timeout) * time.Second,
@@ -284,7 +286,7 @@ Homepage: https://github.com/shenwei356/rush
 		// ---------------------------------------------------------------
 
 		// run
-		chOutput, chSuccessfulCmd, doneSendOutput, chExitStatus := process.Run4Output(opts, cancel, chCmdStr, outfh, errfh)
+		chOutput, chSuccessfulCmd, doneSendOutput, chExitStatus := process.Run4Output(opts, cancel, chCmdStr)
 
 		// read from chOutput and print
 		doneOutput := make(chan int)

--- a/root.go
+++ b/root.go
@@ -170,6 +170,8 @@ Homepage: https://github.com/shenwei356/rush
 		// channel of command
 		chCmdStr := make(chan string, config.Jobs)
 
+		anyCommands := false
+
 		// read data and generate command
 		go func() {
 			n := config.NRecords
@@ -230,9 +232,11 @@ Homepage: https://github.com/shenwei356/rush
 									bfhSuccCmds.Flush()
 								} else {
 									chCmdStr <- cmdStr
+									anyCommands = true
 								}
 							} else {
 								chCmdStr <- cmdStr
+								anyCommands = true
 							}
 
 							id++
@@ -257,9 +261,11 @@ Homepage: https://github.com/shenwei356/rush
 								bfhSuccCmds.Flush()
 							} else {
 								chCmdStr <- cmdStr
+								anyCommands = true
 							}
 						} else {
 							chCmdStr <- cmdStr
+							anyCommands = true
 						}
 					}
 				}
@@ -372,10 +378,12 @@ Homepage: https://github.com/shenwei356/rush
 		<-cleanupDone
 
 		if config.PropExitStatus {
-			if pToolExitStatus != nil {
-				os.Exit(*pToolExitStatus)
-			} else {
-				checkError(fmt.Errorf(`did not get an exit status int from any child process)`))
+			if anyCommands {
+				if pToolExitStatus != nil {
+					os.Exit(*pToolExitStatus)
+				} else {
+					checkError(fmt.Errorf(`did not get an exit status int from any child process)`))
+				}
 			}
 		}
 	},

--- a/root.go
+++ b/root.go
@@ -31,8 +31,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/bburgin/rush/process"
 	"github.com/pkg/errors"
+	"github.com/shenwei356/rush/process"
 	"github.com/shenwei356/util/stringutil"
 	"github.com/shenwei356/xopen"
 	"github.com/spf13/cobra"

--- a/root.go
+++ b/root.go
@@ -32,7 +32,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/shenwei356/rush/process"
+	"github.com/bburgin/rush/process"
 	"github.com/shenwei356/util/stringutil"
 	"github.com/shenwei356/xopen"
 	"github.com/spf13/cobra"
@@ -133,8 +133,11 @@ Homepage: https://github.com/shenwei356/rush
 			KeepOrder:           config.KeepOrder,
 			Retries:             config.Retries,
 			RetryInterval:       time.Duration(config.RetryInterval) * time.Second,
+			PrintRetryOutput:    config.PrintRetryOutput,
 			Timeout:             time.Duration(config.Timeout) * time.Second,
 			StopOnErr:           config.StopOnErr,
+			PropExitStatus:      config.PropExitStatus,
+			KillOnCtrlC:         config.KillOnCtrlC,
 			Verbose:             config.Verbose,
 			RecordSuccessfulCmd: config.Continue,
 		}
@@ -273,7 +276,7 @@ Homepage: https://github.com/shenwei356/rush
 		// ---------------------------------------------------------------
 
 		// run
-		chOutput, chSuccessfulCmd, doneSendOutput := process.Run4Output(opts, cancel, chCmdStr)
+		chOutput, chSuccessfulCmd, doneSendOutput, chExitStatus  := process.Run4Output(opts, cancel, chCmdStr)
 
 		// read from chOutput and print
 		doneOutput := make(chan int)
@@ -302,6 +305,35 @@ Homepage: https://github.com/shenwei356/rush
 			}()
 		}
 
+		var pToolExitStatus *int = nil
+		var doneExitStatus chan int
+		if config.PropExitStatus {
+			doneExitStatus = make(chan int)
+			toolExitStatus := 0
+			go func() {
+				for childCode := range chExitStatus {
+					setPointer := false
+					setCode := false
+					if pToolExitStatus == nil {
+						setPointer = true
+						setCode = true
+					} else {
+						// use the code from the first error we received
+						if *pToolExitStatus == 0 && childCode != 0 {
+							setCode = true
+						}
+					}
+					if setPointer {
+						pToolExitStatus = &toolExitStatus
+					}
+					if setCode {
+						*pToolExitStatus = childCode
+					}
+				}
+				doneExitStatus <- 1
+			}()
+		}
+
 		// ---------------------------------------------------------------
 
 		chExitSignalMonitor := make(chan struct{})
@@ -325,16 +357,27 @@ Homepage: https://github.com/shenwei356/rush
 			}
 		}()
 
-		// the order is very important!
+			// the order is very important!
 		<-donePreprocessFiles // finish read data and send command
 		<-doneSendOutput      // finish send output
 		<-doneOutput          // finish print output
+		if config.PropExitStatus {
+			<-doneExitStatus
+		}
 		if config.Continue {
 			<-doneSaveSuccCmd
 		}
 
 		close(chExitSignalMonitor)
 		<-cleanupDone
+
+		if config.PropExitStatus {
+			if pToolExitStatus != nil {
+				os.Exit(*pToolExitStatus)
+			} else {
+				checkError(fmt.Errorf(`did not get an exit status int from any child process)`))
+			}
+		}
 	},
 }
 
@@ -369,10 +412,13 @@ func init() {
 
 	RootCmd.Flags().IntP("retries", "r", 0, "maximum retries (default 0)")
 	RootCmd.Flags().IntP("retry-interval", "", 0, "retry interval (unit: second) (default 0)")
+	RootCmd.Flags().BoolP("print-retry-output", "", true, "print output from retry commands")
 	RootCmd.Flags().IntP("timeout", "t", 0, "timeout of a command (unit: second, 0 for no timeout) (default 0)")
 
 	RootCmd.Flags().BoolP("keep-order", "k", false, "keep output in order of input")
 	RootCmd.Flags().BoolP("stop-on-error", "e", false, "stop all processes on first error(s)")
+	RootCmd.Flags().BoolP("propagate-exit-status", "", true, "propagate child exit status up to the exit status of rush")
+	RootCmd.Flags().BoolP("kill-on-ctrl-c", "", true, "kill child processes on ctrl-c")
 	RootCmd.Flags().BoolP("dry-run", "", false, "print command but not run")
 
 	RootCmd.Flags().BoolP("continue", "c", false, `continue jobs.`+
@@ -486,11 +532,14 @@ type Config struct {
 
 	Retries       int
 	RetryInterval int
+	PrintRetryOutput bool
 	Timeout       int
 
 	KeepOrder bool
 	StopOnErr bool
-	DryRun    bool
+	PropExitStatus bool
+	KillOnCtrlC bool
+	DryRun     bool
 
 	Continue    bool
 	SuccCmdFile string
@@ -549,13 +598,16 @@ func getConfigs(cmd *cobra.Command) Config {
 		NRecords:             getFlagPositiveInt(cmd, "nrecords"),
 		FieldDelimiter:       getFlagString(cmd, "field-delimiter"),
 
-		Retries:       getFlagNonNegativeInt(cmd, "retries"),
-		RetryInterval: getFlagNonNegativeInt(cmd, "retry-interval"),
-		Timeout:       getFlagNonNegativeInt(cmd, "timeout"),
+		Retries:          getFlagNonNegativeInt(cmd, "retries"),
+		RetryInterval:    getFlagNonNegativeInt(cmd, "retry-interval"),
+		PrintRetryOutput: getFlagBool(cmd, "print-retry-output"),
+		Timeout:          getFlagNonNegativeInt(cmd, "timeout"),
 
-		KeepOrder: getFlagBool(cmd, "keep-order"),
-		StopOnErr: getFlagBool(cmd, "stop-on-error"),
-		DryRun:    getFlagBool(cmd, "dry-run"),
+		KeepOrder:      getFlagBool(cmd, "keep-order"),
+		StopOnErr:      getFlagBool(cmd, "stop-on-error"),
+		PropExitStatus: getFlagBool(cmd, "propagate-exit-status"),
+		KillOnCtrlC:    getFlagBool(cmd, "kill-on-ctrl-c"),
+		DryRun:         getFlagBool(cmd, "dry-run"),
 
 		Continue:    getFlagBool(cmd, "continue"),
 		SuccCmdFile: getFlagString(cmd, "succ-cmd-file"),


### PR DESCRIPTION
Fixes #17 
1. Added graceful Ctrl+C logic, for these user operations:
    a. The user presses Ctrl+C during a rush run, or
    b. The user has specified -e and a child process returns an error
2. rush now follows this fallback sequence for Ctrl+C:
    a. Sends Ctrl+C to child processes
    b. Waits for child processes to disappear or cleanup time to elapse
    c. If processes still exist, sends Ctrl+Break to child processes
    d. Again, waits for processes to disappear or cleanup time to elapse
    e. If processes still exist, finally kills child processes
3. I removed the --kill-on-ctrl-c arg and added --no-stop-exes, --no-kill-exes, and --cleanup-time args
    a. There is no need for the --kill-on-ctrl-c arg now.
        I have removed it in lieu of the more flexible --no-kill-exes arg.
    b. The user needs to use the new --no-kill-exes arg and can rely on its default value of empty list to get the old default behavior of --kill-on-ctrl-c arg=true
    c. For the old --kill-on-ctrl-c=false behavior, the user needs to specify --no-kill-exes all