### PR TITLE
Ctrl+C logic improvement: check start times of known children

### DIFF
--- a/process/process_others.go
+++ b/process/process_others.go
@@ -23,31 +23,38 @@
 package process
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
+	"syscall"
 )
 
 func getProcess(pid int) (processHandle int, processExists bool, accessGranted bool, err error) {
-	// just use the pid as the process handle
-	processHandle = pid
-	// check if the process exists
-	processExists = doesProcessExist(processHandle)
-	// check if we have access to send a signal to the process
-	pidStr := strconv.Itoa(pid)
-	_, err = exec.Command("kill", "-0", pidStr).Output()
-	if err == nil {
-		accessGranted = true
-	} else {
-		accessGranted = false
+	processHandle = INVALID_HANDLE
+	processExists = doesProcessExist(pid)
+	accessGranted = false
+	if processExists {
+		// check if we have access to send a signal to the process
+		pidStr := strconv.Itoa(pid)
+		_, err = exec.Command("kill", "-0", pidStr).Output()
+		if err == nil {
+			// just use the pid as the process handle
+			processHandle = pid
+			accessGranted = true
+		}
 	}
 	return processHandle, processExists, accessGranted, err
 }
 
-func releaseProcess(processHandle int) {
+func releaseProcessByHandle(processHandle int) {
 	// nothing to release
 }
 
@@ -62,6 +69,90 @@ func doesProcessExist(processHandle int) (processExists bool) {
 		processExists = true
 	}
 	return processExists
+}
+
+// from https://github.com/cloudfoundry/gosigar/blob/master/sigar_linux.go
+var system struct {
+	ticks uint64
+	btime uint64
+}
+
+var Procd string
+
+func readFile(file string, handler func(string) bool) error {
+	contents, err := ioutil.ReadFile(file)
+	if err != nil {
+		return err
+	}
+
+	reader := bufio.NewReader(bytes.NewBuffer(contents))
+
+	for {
+		line, _, err := reader.ReadLine()
+		if err == io.EOF {
+			break
+		}
+		if !handler(string(line)) {
+			break
+		}
+	}
+
+	return nil
+}
+
+func init() {
+	system.ticks = 100 // C.sysconf(C._SC_CLK_TCK)
+
+	Procd = "/proc"
+
+	// grab system boot time
+	readFile(Procd+"/stat", func(line string) bool {
+		if strings.HasPrefix(line, "btime") {
+			system.btime, _ = strtoull(line[6:])
+			return false // stop reading
+		}
+		return true
+	})
+}
+
+func strtoull(val string) (uint64, error) {
+	return strconv.ParseUint(val, 10, 64)
+}
+
+func procFileName(pid int, name string) string {
+	return Procd + "/" + strconv.Itoa(pid) + "/" + name
+}
+
+func readProcFile(pid int, name string) ([]byte, error) {
+	path := procFileName(pid, name)
+	contents, err := ioutil.ReadFile(path)
+
+	if err != nil {
+		if perr, ok := err.(*os.PathError); ok {
+			if perr.Err == syscall.ENOENT {
+				return nil, syscall.ESRCH
+			}
+		}
+	}
+
+	return contents, err
+}
+
+func _getProcessStartTime(processHandle int) (startTime uint64, err error) {
+	startTime = 0
+	// just use the process handle as the pid
+	pid := processHandle
+	contents, err := readProcFile(pid, "stat")
+	if err == nil {
+		fields := strings.Fields(string(contents))
+
+		// convert to millis
+		startTime, _ = strtoull(fields[21])
+		startTime /= system.ticks
+		startTime += system.btime
+		startTime *= 1000
+	}
+	return
 }
 
 func getShell() (shell string) {
@@ -105,7 +196,7 @@ func getSignalsToSend(childProcessName string, noStopExes []string, noKillExes [
 
 func doesChildHaveMarker(processHandle int) (hasMarker bool, err error) {
 	// the process handle is the pid
-	envCmd := fmt.Sprintf("xargs -0 -n 1 < /proc/%d/environ", processHandle)
+	envCmd := fmt.Sprintf("xargs -0 -n 1 < %s/%d/environ", Procd, processHandle)
 	env, err := exec.Command(getShell(), "-c", envCmd).Output()
 	if err == nil {
 		hasMarker = containsMarker(string(env))


### PR DESCRIPTION
To allow rush to stop child processes that have cleared their environment (but are not orphaned),
match children by first checking the process start times of known child processes, then fallback to the env variable check.