### PR TITLE
try to solve hang up after typing ctrl-c

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 - rush v0.5.1
+    - `-c`: fix a bug -- some commands are recorded even after unsuccessfully running or interrupting with Ctrl+C. [#47](https://github.com/shenwei356/rush/issues/47)
     - `--eta`: add counts for finished commands.
 - rush v0.5.0
     - add flag `--eta` to show ETA progress bar. Thanks to @howeyc. [#39](https://github.com/shenwei356/rush/pull/39)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 - rush v0.5.1
+    - graceful handling of Ctrl+C.
     - `-c`: fix a bug -- some commands are recorded even after unsuccessfully running or interrupting with Ctrl+C. [#47](https://github.com/shenwei356/rush/issues/47)
     - `--eta`: add counts for finished commands.
 - rush v0.5.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,5 @@
+- rush v0.5.1
+    - `--eta`: add counts for finished commands.
 - rush v0.5.0
     - add flag `--eta` to show ETA progress bar. Thanks to @howeyc. [#39](https://github.com/shenwei356/rush/pull/39)
 - rush v0.4.3

--- a/helper.go
+++ b/helper.go
@@ -30,7 +30,7 @@ import (
 )
 
 // VERSION of this package
-const VERSION = "0.5.0"
+const VERSION = "0.5.1"
 
 func isStdin(file string) bool {
 	return file == "-"

--- a/root.go
+++ b/root.go
@@ -255,6 +255,10 @@ Homepage: https://github.com/shenwei356/rush
 						if config.Continue {
 							if _, runned = succCmds[cmdStr]; runned {
 								log.Infof("ignore cmd: %s", cmdStr)
+								if opts.ETA {
+									opts.ETABar.Add(1)
+									fmt.Fprintln(os.Stderr)
+								}
 								// bfhSuccCmds.WriteString(cmdStr + endMarkOfCMD)
 								// bfhSuccCmds.Flush()
 							} else {


### PR DESCRIPTION
Hi @bburgin, I'm trying to solve hang after typing Ctrl + C.

     seq 100 | rush 'sleep 1' --eta 

Previously, it hung up, even after checking all child processes. I just added [one line](https://github.com/shenwei356/rush/blob/2a365241cbc72f9f8b2b849c85f37c276c3b8795/process/process.go#L1043) to fix it.

I also found it [takes a long time to check the child process](https://github.com/shenwei356/rush/blob/28d997f6410ac4f489aa59a675ad55bd05cee401/process/process.go#L713-L722).  So I [parallize it](https://github.com/shenwei356/rush/blob/2a365241cbc72f9f8b2b849c85f37c276c3b8795/process/process.go#L1043), but strangely it would panic when using 16 goroutines. Using eight would not.