### PR TITLE
fix: panic due casting to []rune in WritePrefixedLines

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -352,18 +352,16 @@ func (lw *ImmediateLineWriter) WritePrefixedLines(input string, outfh *os.File) 
 			reg := regexp.MustCompile("(?:\r\n|\n)")
 			matchExtents := reg.FindAllStringIndex(input, -1)
 			if len(matchExtents) > 0 {
-				// use runes below, so we work correctly with unicode strings
-				rs := []rune(input)
 				lastStart := 0
 				for _, matchExtent := range matchExtents {
-					beforePart := string(rs[lastStart:matchExtent[0]])
+					beforePart := input[lastStart:matchExtent[0]]
 					lw.line = lw.line + beforePart
 					// skip empty lines
 					if len(lw.line) > 0 {
 						// there is some data in this part, so add prefix if needed
 						lw.addPrefixIfNeeded(&output)
 						// append the chars up to and including the delimiter
-						delimiterPart := string(rs[matchExtent[0]:matchExtent[1]])
+						delimiterPart := input[matchExtent[0]:matchExtent[1]]
 						output = output + beforePart + delimiterPart
 						// defer including prefix, so only add it on next non-empty data
 						lw.includePrefix = true
@@ -374,8 +372,8 @@ func (lw *ImmediateLineWriter) WritePrefixedLines(input string, outfh *os.File) 
 					lastStart = matchExtent[1]
 				}
 				// append any remaining chars after the last delimiter
-				if lastStart < len(rs) {
-					lastPart := string(rs[lastStart:])
+				if lastStart < len(input) {
+					lastPart := input[lastStart:]
 					// there is some data in this part, so add prefix if needed
 					lw.addPrefixIfNeeded(&output)
 					lw.line = lw.line + lastPart


### PR DESCRIPTION
# Bug
There is a panic `slice bounds out of range` in `ImmediateLineWriter.WritePrefixedLines` cause `regex.FindAllStringIndex` returns byte indexes and we try to match these indexes in slice of runes which is incorrect when input string has 2 byte symbols.

## Way to reproduce
windows (git bash)
```sh
seq 1 2 | ./rush --immediate-output printf "один123\nдва1234\nтри123\n"
```
macOS
```sh
seq 1 2 | ./rush --immediate-output echo -e "один123\nдва1234\nтри123\n"
```
or this simple test demonstrates it
```go
package process

import (
	"sync"
	"testing"
)

func TestImmediateLineWriter_WritePrefixedLines(t *testing.T) {
	const inputThatPanics = `один123
два1234
три123
`
	t.Run("panic occurs", func(t *testing.T) {
		lw := &ImmediateLineWriter{
			lock:    &sync.Mutex{},
			numJobs: 2,
		}

		lw.WritePrefixedLines(inputThatPanics, nil)
	})
}
```

# Fix
 By removing unnecessary casting input string to []rune: `regex.FindAllStringIndex` returns byte indexes so we can directly access string parts by these indexes.

