### PR TITLE
docs: aligned help message

### DIFF
--- a/root.go
+++ b/root.go
@@ -74,7 +74,7 @@ Replacement strings in commands:
   {#}         job ID
   {n}         nth field in delimiter-delimited data
   {/}         dirname
-  {%%}        basename
+  {%%}         basename
   {.}         remove the last file extension
   {:}         remove all file extensions.
   {^suffix}   remove suffix


### PR DESCRIPTION
Tiny minor PR to align the help message.

This PR visually aligns the help message while making the code not aligned ;)

aligning `{%} basename` with the rest of the help message's section.

from
```
Replacement strings in commands:
  {}          full data
  {#}         job ID
  {n}         nth field in delimiter-delimited data
  {/}         dirname
  {%}        basename
  {.}         remove the last file extension
  {:}         remove all file extensions.
  {^suffix}   remove suffix
  {@regexp}   capture submatch using regular expression.
              Limitation: curly brackets can't be used in the regexp.
```

to

```
Replacement strings in commands:
  {}          full data
  {#}         job ID
  {n}         nth field in delimiter-delimited data
  {/}         dirname
  {%}         basename
  {.}         remove the last file extension
  {:}         remove all file extensions.
  {^suffix}   remove suffix
  {@regexp}   capture submatch using regular expression.
              Limitation: curly brackets can't be used in the regexp.
```